### PR TITLE
Fix r100/dllversion test failure due to copyright changes changing th…

### DIFF
--- a/com/random_ver.csh
+++ b/com/random_ver.csh
@@ -176,7 +176,12 @@ if ($?vertype) then
 	case "shlib_mismatch":
 		# First 64 bit supported versions on these platforms which will work with the current versions
 		if ("HOST_LINUX_X86_64" == $gtm_test_os_machtype || "HOST_AIX_RS6000" == $gtm_test_os_machtype) then
-			set minimum = "V53001"
+			if (! $?ydb_environment_init) then
+				set minimum = "V53001"
+			else
+				# Below is minimum 64-bit build we have on a YDB environment.
+				set minimum = "V54001"
+			endif
 		else if ("HOST_SUNOS_SPARC" == $gtm_test_os_machtype) then
 			set minimum = "V53002"
 		else if ("HOST_OS390_S390" == $gtm_test_os_machtype) then

--- a/r100/outref/dllversion_oneversion.txt
+++ b/r100/outref/dllversion_oneversion.txt
@@ -6,6 +6,6 @@ Hello World
 ##TEST_AWK\$ZVERSION=.*
 ##TEST_AWK.*
 %GTM-E-DLLVERSION, Routine helloworld in library ##TEST_PATH##/shlib was compiled with an incompatible version of GT.M/YottaDB.  Recompile with the current version of YottaDB and re-link
-		At M source location +6^drivehw
+##TEST_AWK		At M source location \+[0-9]*\^drivehw
 
 GTM>


### PR DESCRIPTION
…e line # in drivehw.m where the DLLVERSION error is issued; Also set the minimum version as V54001 for shlib_mismatch calls to random_ver as the V53001 build in YDB setup is 32-bit whereas the shlib to be created assumes it is 64-bit