### PR TITLE
Fix r100/dllversion test failure if V54001 is chosen as prior version…

### DIFF
--- a/r100/inref/drivehw.m
+++ b/r100/inref/drivehw.m
@@ -9,7 +9,7 @@
 ;	the license, please stop and do not read further.	;
 ;								;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-	zwrite $zversion
+	write "$ZVERSION=",$zversion,!
 	do
 	. new $etrap
 	. set $etrap="set $ecode="""" write ""This is an original GT.M release"",! quit"


### PR DESCRIPTION
… since ZWRITE $ZVERSION (used by drivehw.m) is not supported there; Simulate the ZWRITE using WRITE command instead