### PR TITLE
(#32 callinperf) - Add new subtests to call-ins suite plus fixup test…

### DIFF
--- a/call_ins/inref/divzro.m
+++ b/call_ins/inref/divzro.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -14,9 +17,9 @@
     W !,"divzro: $ZLEVEL = ",$ZLEVEL
     W !,"divzro: $STACK = ",$STACK
     W !,"divzro: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro = ",$stack(0,"ECODE")
     W !,1/0
     Q
 ERR

--- a/call_ins/inref/divzro2.m
+++ b/call_ins/inref/divzro2.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -13,9 +16,9 @@
     W !,"M2: $ZLEVEL = ",$ZLEVEL
     W !,"M2: $STACK = ",$STACK
     W !,"M2: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro2 = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro2 = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro2 = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro2 = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro2 = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro2 = ",$stack(0,"ECODE")
     W !,1/0
     Use 0
     Q

--- a/call_ins/inref/divzro3.m
+++ b/call_ins/inref/divzro3.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -13,9 +16,9 @@
     W !,"M2: $ZLEVEL = ",$ZLEVEL
     W !,"M2: $STACK = ",$STACK
     W !,"M2: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro3 = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro3 = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro3 = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro3 = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro3 = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro3 = ",$stack(0,"ECODE")
     W !,1/0
     Use 0
     Q

--- a/call_ins/inref/divzro4.m
+++ b/call_ins/inref/divzro4.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -13,9 +16,9 @@
     W !,"M2: $ZLEVEL = ",$ZLEVEL
     W !,"M2: $STACK = ",$STACK
     W !,"M2: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro4 = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro4 = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro4 = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro4 = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro4 = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro4 = ",$stack(0,"ECODE")
     W !,1/0
     Use 0
     Q

--- a/call_ins/inref/drivecirtn.c
+++ b/call_ins/inref/drivecirtn.c
@@ -1,0 +1,46 @@
+/****************************************************************
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "gtmxc_types.h"
+
+#define ERRBUF_SIZE	1024
+
+/* Routine to take the name of an M routine as an argument and invoke it via a call-in. Probably not useful in
+ * real world applications but makes writing test cases for call-ins much easier.
+ */
+gtm_status_t drivecirtn(gtm_int_t count, gtm_char_t *rtnname)
+{
+	gtm_status_t		status;
+	char			errbuf[ERRBUF_SIZE];
+
+	status = gtm_init();
+	if (status)
+	{
+		gtm_zstatus(errbuf, ERRBUF_SIZE);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+		return 0;
+	}
+	status = gtm_ci(rtnname);
+	if (status)
+	{
+		gtm_zstatus(errbuf, ERRBUF_SIZE);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+		return 0;
+	}
+	return 0;
+}

--- a/call_ins/inref/dvzrozt.m
+++ b/call_ins/inref/dvzrozt.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -13,9 +16,9 @@
     W !,"divzro: $ZLEVEL = ",$ZLEVEL
     W !,"divzro: $STACK = ",$STACK
     W !,"divzro: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro = ",$stack(0,"ECODE")
     W !,1/0
     Use 0
     Q

--- a/call_ins/inref/dvzrozt2.m
+++ b/call_ins/inref/dvzrozt2.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -13,9 +16,9 @@
     W !,"M2: $ZLEVEL = ",$ZLEVEL
     W !,"M2: $STACK = ",$STACK
     W !,"M2: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro2 = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro2 = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro2 = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro2 = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro2 = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro2 = ",$stack(0,"ECODE")
     W !,1/0
     Use 0
     Q

--- a/call_ins/inref/dvzrozt3.m
+++ b/call_ins/inref/dvzrozt3.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -13,9 +16,9 @@
     W !,"M2: $ZLEVEL = ",$ZLEVEL
     W !,"M2: $STACK = ",$STACK
     W !,"M2: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro3 = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro3 = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro3 = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro3 = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro3 = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro3 = ",$stack(0,"ECODE")
     W !,1/0
     Q
 ERR

--- a/call_ins/inref/dvzrozt4.m
+++ b/call_ins/inref/dvzrozt4.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2003-2015 Fidelity National Information 	;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -13,9 +16,9 @@
     W !,"M2: $ZLEVEL = ",$ZLEVEL
     W !,"M2: $STACK = ",$STACK
     W !,"M2: $ESTACK = ",$ESTACK
-    w !,"$stack(1,""PLACE"") in divzro4 = ",$stack(1,"PLACE")
-    w !,"$stack(1,""MCODE"") in divzro4 = ",$stack(1,"MCODE")
-    w !,"$stack(1,""ECODE"") in divzro4 = ",$stack(1,"ECODE")
+    w !,"$stack(0,""PLACE"") in divzro4 = ",$stack(0,"PLACE")
+    w !,"$stack(0,""MCODE"") in divzro4 = ",$stack(0,"MCODE")
+    w !,"$stack(0,""ECODE"") in divzro4 = ",$stack(0,"ECODE")
     W !,1/0
     Use 0
     Q

--- a/call_ins/inref/environment.m
+++ b/call_ins/inref/environment.m
@@ -1,0 +1,44 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.	     	  	     			;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; Routine to exercise $VIEW("ENVIRONMENT") in various situations.
+;
+environment
+	;
+	; First just run it in open runtime code - should give "MUMPS"
+	;
+	write "Return value from $VIEW(""ENVIRONMENT"") in runtime code: ",$view("ENVIRONMENT"),!
+	;
+	; Need to test in a callin so drive a call-out first to a call-in to the environci entry point below
+	;
+	write !,"Driving external call/callin to check value in that environment (follows):",!
+	set cirtnname="environci"
+	do &drivecirtn(.cirtnname)
+	;
+	; Now update a global which will fire a trigger both on the primary and secondary doing the
+	; same thing.
+	;
+	write !,"Driving trigger to show $VIEW(""ENVIRONMENT"") - value there follows:",!
+	set ^A=42
+	quit
+
+;
+; Entry point drive by call-in (after call-out) to drive $VIEW("ENVIRONMENT") in that situation
+;
+environci
+	write !,"Return value from $VIEW(""ENVIRONMENT"") in call-in mode: ",$view("ENVIRONMENT"),!
+	;
+	; We're in a call-in - let's drive a trigger too
+	;
+	write !,"Driving trigger to show $VIEW(""ENVIRONMENT"") from inside a CALL-IN - value there follows:",!
+	set ^A=41
+	quit

--- a/call_ins/inref/gtmxc_test_types.c
+++ b/call_ins/inref/gtmxc_test_types.c
@@ -1,13 +1,17 @@
 /****************************************************************
-*								*
-*	Copyright 2007, 2014 Fidelity Information Services, Inc	*
-*								*
-*	This source code contains the intellectual property	*
-*	of its copyright holder(s), and is made available	*
-*	under a license.  If you do not know the terms of	*
-*	the license, please stop and do not read further.	*
-*								*
-****************************************************************/
+ *								*
+ * Copyright (c) 2007-2014 Fidelity National Information	*
+ * Services, Inc. and/or its subsidiaries. All rights reserved.	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
 /* The following tests exercise call_ins to M from C routines using all the gtm types from
    gtmxc_types.h.  For the I: types pointer and non-pointer arguments are valid.  For the IO:
    and O: types only pointer arguments are valid.  The first 8 are I: tests where the C routine
@@ -54,6 +58,7 @@ int main()
 	gtm_string_t arg8;
 	gtm_char_t buf0[100];
 	gtm_char_t buf[100];
+	ci_name_descriptor	ydb_test9;
 
 	fflush(stdout);
 	retval8.address = buf;
@@ -216,7 +221,10 @@ int main()
 	fflush(stdout);
 
 	/* test9 returns gtm_int_t * */
-	status = gtm_ci("gtmxc_test9", &retval1, &arg1, &arg2, &arg3, &arg4, &arg5, &arg6, arg7, &arg8);
+	ydb_test9.rtn_name.address = "gtmxc_test9";
+	ydb_test9.rtn_name.length = sizeof("gtmxc_test9") - 1;
+	ydb_test9.handle = NULL;
+	status = gtm_cip(&ydb_test9, &retval1, &arg1, &arg2, &arg3, &arg4, &arg5, &arg6, arg7, &arg8);
 	if (status)
 	{
 		gtm_zstatus(&errmsg[0], 800);

--- a/call_ins/inref/testcizgoto01.m
+++ b/call_ins/inref/testcizgoto01.m
@@ -1,0 +1,19 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See test_ci_zgoto0.csh for a description of this test
+;
+testcizgoto01
+	write "testcizgoto01: Entered - Driving ^testcizgoto0A",!
+	do ^testcizgoto0A	; Placing this routine on the stack for now but will mod it later
+	write "testcizgoto01: Back in testcizgoto01 - Test complete",!
+	quit

--- a/call_ins/inref/testcizgoto02.m
+++ b/call_ins/inref/testcizgoto02.m
@@ -1,0 +1,21 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See test_ci_zgoto0.csh for a description of this test - this is the first target of the call-in
+;
+testcizgoto02
+	new $etrap
+	set $etrap="write ""testcizgoto02: ** Error** : "",$zstatus,!,""Aborting testcizgoto02"",!"
+	write "testcizgoto02: Entered - driving ZGOTO 0 now to return to call-in caller",!
+	zgoto 0
+	write "testcizgoto02: Should never happen",!
+	zhalt 99

--- a/call_ins/inref/testcizhalt1.m
+++ b/call_ins/inref/testcizhalt1.m
@@ -1,0 +1,19 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See test_ci_z_halt.csh for a description of this test
+;
+testcizhalt1
+	write "testcizhalt1: Entered - Driving ^testcizhaltA",!
+	do ^testcizhaltA	; Placing this routine on the stack for now but will mod it later
+	write "testcizhalt1: Back in testcizhalt1 - Test complete",!
+	quit

--- a/call_ins/inref/testcizhalt2.m
+++ b/call_ins/inref/testcizhalt2.m
@@ -1,0 +1,19 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See test_ci_z_halt.csh for a description of this test - this is the first target of the call-in
+;
+testcizhalt2
+	new $etrap
+	set $etrap="write ""testcizhalt2: ** Error** : "",$zstatus,!,""Aborting testcizhalt2"",!"
+	write "testcizhalt2: Entered - driving HALT now to return to call-in caller",!
+	halt

--- a/call_ins/inref/testcizhalt3.m
+++ b/call_ins/inref/testcizhalt3.m
@@ -1,0 +1,19 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See test_ci_z_halt.csh for a description of this test - this is the second target of the call-in
+;
+testcizhalt3
+	new $etrap
+	set $etrap="write ""testcizhalt3: ** Error** : "",$zstatus,!,""Aborting testcizhalt3"",!"
+	write "testcizhalt3: Entered - driving ZHALT now to return to call-in caller",!
+	zhalt 1		     ; Note if any rc but 0 or 1, intoduces a blank line in reference file

--- a/call_ins/inref/testmprofhiddenrtn1.m
+++ b/call_ins/inref/testmprofhiddenrtn1.m
@@ -1,0 +1,46 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See test_mprof_hidden_rtn.csh for a description of this test
+;
+testmprofhiddenrtn1
+	view "TRACE":1:"^mproftrc"
+	write "testmprofhiddenrtn1: Entered - Driving ^testmprofhiddenrtnA",!
+	do ^testmprofhiddenrtnA	; Placing this routine on the stack for now but will mod it later
+	write "testmprofhiddenrtn1: Back in testmprofhiddenrtn1 - writing out mprof trace and exiting",!
+	view "TRACE":0
+	set fn="mproftrc.out"
+	open fn:new
+	use fn
+	zwr ^mproftrc
+	close fn
+	;
+	; Take a look at the mprofiling entry for ^mproftrc("testmprofhiddenrtnA","testmprofhiddenrtnA"). This node shows what
+	; happens when M-Profiling cannot look back past the call-in base frame. In versions prior to V63002_R110, the data
+	; returned in this node is quite very wrong:
+	;
+	;    Typical value prior to V63002_R110: "2:43:3214:3257:1295610162690"
+	;
+	;    Typcal value for V63002_R110:       "1:0:289:289:290"
+	;
+	; So we'll do a quick check on the first and last values to verify whether test fails or succeeds
+	;
+	set tstval=^mproftrc("testmprofhiddenrtnA","testmprofhiddenrtnA")
+	set count=$zpiece(tstval,":",1)
+	set elap=$zpiece(tstval,":",5)
+	if (1'=count) do
+	. write "testmprofhiddenrtn1: FAIL - count in node ^mproftrc(""testmprofhiddenrtnA"",""testmprofhiddenrtnA"") is wrong",!
+	else  if (1000000<elap) do
+	. write "testmprofhiddenrtn1: FAIL - elaspsed time exceeds 1 second",!
+	else  write "testmprofhiddenrtn1: PASS",!
+	write "testmprofhiddenrtn1: Test complete",!
+	quit

--- a/call_ins/inref/testmprofhiddenrtn2.m
+++ b/call_ins/inref/testmprofhiddenrtn2.m
@@ -1,0 +1,20 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See replace_rtn.csh for a description of this test - this is the target of the call-in
+;
+testmprofhiddenrtn2
+	new $etrap
+	set $etrap="write ""testmprofhiddenrtn2: ** Error** : "",$zstatus,!,""Aborting testmprofhiddenrtn2"",!"
+	write "testmprofhiddenrtn2: Entered",!
+	write "testmprofhiddenrtn2: Returning",!
+	quit

--- a/call_ins/inref/testrtnreplc1.m
+++ b/call_ins/inref/testrtnreplc1.m
@@ -1,0 +1,22 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See replace_rtn.csh for a description of this test
+;
+testrtnreplc1
+	write "testrtnreplc1: Entered - initialize some vars to play with",!
+	set a=42,b=4242,c=424242
+	write "testrtnreplc1: Driving call-in",!
+	do ^testrtnreplcA	; Placing this routine on the stack for now but will mod it later
+	write "testrtnreplc1: Back in testrtnreplc1 - variable values:",!
+	zshow "V"
+	quit

--- a/call_ins/inref/testrtnreplc2.m
+++ b/call_ins/inref/testrtnreplc2.m
@@ -1,0 +1,48 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See replace_rtn.csh for a description of this test - this is the target of the call-in
+;
+testrtnreplc2
+	new $etrap
+	set $etrap="write ""testrtnreplc2: ** Error** : "",$zstatus,!,""Aborting testrtnreplc2"",!"
+	write "testrtnreplc2: Entered - creating alternate testrtnreplcA routine",!
+	;
+	; We've been entered via call-in. First up, create a new version of testrtnreplcA.m to replace the
+	; one that is on the stack now after renaming the original so it stays in the test directory.
+	;
+	zsystem "mv testrtnreplcA.m testrtnreplcA.m.original"
+	if (0'=$zsystem) do
+	. write "testrtnreplc2: Failure in zsystem 'mv' command - aborting",!
+	. zhalt 1
+	set fn="testrtnreplcA.m"
+	open fn:new
+	use fn
+	write " write ""testrtnreplcA (replaced): Entered - do some variable play"",!",!
+	write " set a=a*2,b=b*2,c=c*2"
+	write " write ""testrtnreplcA (replaced): Returning"",!",!
+	write " quit",!
+	close fn
+	;
+	; Allow a routine to be re-linked even if on stack. This allows us to have two version of the same
+	; routine active. But if we didn't *find* the old routine because the call-in level prevented it, the
+	; linker will REPLACE the previous routine such that when we unwind to the earlier version and it has
+	; been replace, things won't be pleasant.
+	;
+	view "LINK":"RECURSIVE"
+	write "testrtnreplc2: ZLINKing new version of ^testrtnreplcA",!
+	zlink "testrtnreplcA.m"
+	write "testrtnreplc2: Driving replaced ^testrtnreplcA",!
+	set $etrap=""
+	do ^testrtnreplcA
+	write "testrtnreplc2: Back in testrtnreplc2 -- returning",!
+	quit

--- a/call_ins/inref/testrtnreplc3.m
+++ b/call_ins/inref/testrtnreplc3.m
@@ -1,0 +1,20 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; This routine is invoked merrily to (re)allocate the space freed up when (if) the original version
+; of testrtnreplcA was replaced.
+;
+testrtnreplc3
+	write "testrtnreplc3: Entered - set 3 (different) var with different values",!
+	set x=-1,y=0,z=1
+	write "testrtnreplc3: Returning",!
+	quit

--- a/call_ins/instream.csh
+++ b/call_ins/instream.csh
@@ -1,6 +1,10 @@
 #################################################################
 #								#
-#	Copyright 2003, 2014 Fidelity Information Services, Inc	#
+# Copyright (c) 2003-2014 Fidelity National Information		#
+# Services, Inc. and/or its subsidiaries. All rights reserved.	#
+#                                                               #
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -18,17 +22,26 @@
 # timers		[sopini]	Verify the operation of gtm_start_timer and gtm_cancel_timer operations.
 # empty_table		[sopini]	Ensure that providing an empty table file does not cause SIG-11s.
 # stack_leak		[sopini]	Ensure that call-ins do not leak M stack when gtmci_init() is called repeatedly.
+# environment		[estess]	Test $VIEW("ENVIRONMENT") for MUPIP/CALLIN/TRIGGER values
+# test_rtn_replace	[estess]	Verify no explosions when routine hiding behind call-in frame is replaced
+# test_mprof_hidden_rtn [estess]	Verify M-Profiling functions correctly when routine is hidden behind a call-in frame
+# test_ci_z_halt	[estess]	Verify [Z]HALT in a call-in returns to caller instead of actually halting
+# test_ci_goto0		[estess]	Verify ZGOTO 0 in a call-in returns to caller after algorithmic change
 #
 # Options to record Load Path in executables. Similar options needed for OS390 platform
+setenv subtest_exclude_list ""
 setenv unicode_testlist "unic2m2c2m unimaxstrlen"
 #
-setenv subtest_list "32args argcnt c_args ctomctom ctomtom gtm_args gtm_errors gtm_exit_err lngargs maxnstlvl nest_err nest_err_et nest_err_et2"
-setenv subtest_list "$subtest_list nest_err_et3 nest_err_zt nest_err_zt2 nest_err_zt3 maxstrlen gtmxc_test_types xc_test_types multi_gtm_init"
-setenv subtest_list "$subtest_list gtm_percent gtm_cip timers empty_table stack_leak"
+setenv subtest_list_common ""
+setenv subtest_list_non_replic "32args argcnt c_args ctomctom ctomtom gtm_args gtm_errors gtm_exit_err lngargs maxnstlvl nest_err nest_err_et"
+setenv subtest_list_non_replic "$subtest_list_non_replic nest_err_et2 nest_err_et3 nest_err_zt nest_err_zt2 nest_err_zt3 maxstrlen gtmxc_test_types"
+setenv subtest_list_non_replic "$subtest_list_non_replic xc_test_types multi_gtm_init gtm_percent gtm_cip timers empty_table stack_leak"
+setenv subtest_list_non_replic "$subtest_list_non_replic test_rtn_replace test_mprof_hidden_rtn test_ci_z_halt test_ci_zgoto0"
+setenv subtest_list_replic "environment"
 
 if ("TRUE" == $gtm_test_unicode_support) then
 	## Unicode supported machine
-	setenv subtest_list "$subtest_list $unicode_testlist"
+	setenv subtest_list_non_replic "$subtest_list_non_replic $unicode_testlist"
 endif
 
 if (1 == $gtm_test_trigger) then
@@ -40,6 +53,13 @@ set hostn = $HOST:r:r:r
 # Disable unic2m2c2m subtest on platforms that do not support 4 byte unicode characters
 if ("1" == "$gtm_platform_no_4byte_utf8") then
 	setenv subtest_exclude_list "unic2m2c2m"
+endif
+
+if ($?test_replic == 1) then
+	setenv subtest_list "$subtest_list_common $subtest_list_replic"
+else
+	setenv subtest_list "$subtest_list_common $subtest_list_non_replic"
+	setenv subtest_exclude_list "$subtest_exclude_list environment"		# Don't run this without replic or it fails
 endif
 
 if ( "os390" == $gtm_test_osname ) then

--- a/call_ins/outref/c_args.txt
+++ b/call_ins/outref/c_args.txt
@@ -10,12 +10,12 @@ mumps.dat
 %GTM-I-JNLSTATE, Journaling state for region DEFAULT is now ON
 
 M1 -> C -> M2
-M2: $ZLEVEL = 2
+M2: $ZLEVEL = 1
  Do ^CUST 
 M1 -> C -> M2 -> M3
-M3: $ZLEVEL = 3
+M3: $ZLEVEL = 2
 M1 -> C -> M2 -> M3
-M3: $ZLEVEL = 3
+M3: $ZLEVEL = 2
 Balance is: 22210.010000
 New rates are: 0.060000
 New balance is: 23542.610653

--- a/call_ins/outref/environment.txt
+++ b/call_ins/outref/environment.txt
@@ -1,0 +1,54 @@
+Files Created in ##TEST_PATH##:
+Using: ##SOURCE_PATH##/mumps -run GDE
+mumps.gld
+Using: ##SOURCE_PATH##/mupip
+mumps.dat
+Files Created in ##REMOTE_TEST_PATH##:
+Using: ##SOURCE_PATH##/mumps -run GDE
+mumps.gld
+Using: ##SOURCE_PATH##/mupip
+mumps.dat
+Starting Primary Source Server in ##TEST_PATH##
+Starting Passive Source Server and Receiver Server in ##REMOTE_TEST_PATH##
+File environment.trg, Line 1: No matching triggers found for deletion
+File environment.trg, Line 2: Added SET trigger on ^A named A#1
+=========================================
+1 triggers added
+0 triggers deleted
+0 triggers modified
+1 trigger file entries did update database trigger content
+1 trigger file entries did not update database trigger content
+=========================================
+Return value from $VIEW("ENVIRONMENT") in runtime code: MUMPS
+
+Driving external call/callin to check value in that environment (follows):
+
+Return value from $VIEW("ENVIRONMENT") in call-in mode: MUMPS,CALLIN
+
+Driving trigger to show $VIEW("ENVIRONMENT") from inside a CALL-IN - value there follows:
+$VIEW("ENVIRONMENT")=MUMPS,TRIGGER,CALLIN
+M-Stack follows:
++1^A#1#
+environci+6^environment
+    (Call-In Level Entry)
+environment+10^environment
+
+Driving trigger to show $VIEW("ENVIRONMENT") - value there follows:
+$VIEW("ENVIRONMENT")=MUMPS,TRIGGER
+M-Stack follows:
++1^A#1#
+environment+16^environment
+
+Shutting down Passive Source Server and Receiver Server in ##REMOTE_TEST_PATH##
+Shutting down Primary Source Server Server in ##TEST_PATH##
+##SOURCE_PATH##/mupip
+##SOURCE_PATH##/mupip integ -REG *
+No errors detected by integ.
+##SOURCE_PATH##/mupip
+##SOURCE_PATH##/mupip integ -REG *
+No errors detected by integ.
+
+Looking for message from update process trigger giving value for $VIEW(ENVIRONMENT):
+$VIEW("ENVIRONMENT")=MUPIP,TRIGGER
+$VIEW("ENVIRONMENT")=MUPIP,TRIGGER
+End of environment subtest

--- a/call_ins/outref/gtm_args.txt
+++ b/call_ins/outref/gtm_args.txt
@@ -30,9 +30,9 @@ Interest rate for acct # 2221001 is currently  0.06
 New interest rate for acct # 2221001 is 2.50
 
  M -->C -> M...
- M2, $ZLEVEL = 4
+ M2, $ZLEVEL = 3
  M -->C -> M...
- M2, $ZLEVEL = 4
+ M2, $ZLEVEL = 3
 
 GTM env. successfully shutdown
 

--- a/call_ins/outref/gtm_exit_err.txt
+++ b/call_ins/outref/gtm_exit_err.txt
@@ -29,11 +29,11 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 
 GTM environment initialized within C...
 
-M2: $ZLEVEL = 2
-M2: $STACK = 1
+M2: $ZLEVEL = 1
+M2: $STACK = 0
 M2: $ESTACK = 1
-$stack(1,"PLACE") in divzro2 = +16^divzro2
-$stack(1,"MCODE") in divzro2 =     w !,"$stack(1,""MCODE"") in divzro2 = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro2 = 
+$stack(0,"PLACE") in divzro2 = +19^divzro2
+$stack(0,"MCODE") in divzro2 =     w !,"$stack(0,""MCODE"") in divzro2 = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro2 = 
 
 Illegal-- attempt to divide by zero

--- a/call_ins/outref/maxnstlvl.txt
+++ b/call_ins/outref/maxnstlvl.txt
@@ -17,7 +17,11 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -37,7 +41,15 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -57,7 +69,19 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -77,7 +101,23 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -97,7 +137,27 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -117,7 +177,31 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -137,7 +221,35 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -157,7 +269,39 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -177,7 +321,43 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)
@@ -197,7 +377,47 @@ end(entry2)
 after entry2: stack =  w zzz,!
 err called
 err+2^test
-+1^GTM$CI
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
+mtoc+6^test
+sub1+2^test
+main+2^test
+    (Call-In Level Entry)
 begin(main)
 
 begin(sub1)

--- a/call_ins/outref/nest_err.txt
+++ b/call_ins/outref/nest_err.txt
@@ -35,13 +35,13 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 GTM environment initialized within C...
 
 Value of $ET in divzro: 
-divzro: $ZLEVEL = 2
-divzro: $STACK = 1
+divzro: $ZLEVEL = 1
+divzro: $STACK = 0
 divzro: $ESTACK = 1
-$stack(1,"PLACE") in divzro = +17^divzro
-$stack(1,"MCODE") in divzro =     w !,"$stack(1,""MCODE"") in divzro = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro = 
- 150373210,+20^divzro,%GTM-E-DIVZERO, Attempt to divide by zero 
+$stack(0,"PLACE") in divzro = +20^divzro
+$stack(0,"MCODE") in divzro =     w !,"$stack(0,""MCODE"") in divzro = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro = 
+ 150373210,+23^divzro,%GTM-E-DIVZERO, Attempt to divide by zero 
 
 Values returned from inmult:
 

--- a/call_ins/outref/nest_err_et.txt
+++ b/call_ins/outref/nest_err_et.txt
@@ -34,14 +34,14 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 
 GTM environment initialized within C...
 
-M2: $ZLEVEL = 2
-M2: $STACK = 1
+M2: $ZLEVEL = 1
+M2: $STACK = 0
 M2: $ESTACK = 1
-$stack(1,"PLACE") in divzro2 = +16^divzro2
-$stack(1,"MCODE") in divzro2 =     w !,"$stack(1,""MCODE"") in divzro2 = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro2 = 
+$stack(0,"PLACE") in divzro2 = +19^divzro2
+$stack(0,"MCODE") in divzro2 =     w !,"$stack(0,""MCODE"") in divzro2 = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro2 = 
 
-Illegal-- attempt to divide by zero 150373210,+19^divzro2,%GTM-E-DIVZERO, Attempt to divide by zero 
+Illegal-- attempt to divide by zero 150373210,+22^divzro2,%GTM-E-DIVZERO, Attempt to divide by zero 
 
 Values returned from inmult:
 

--- a/call_ins/outref/nest_err_et2.txt
+++ b/call_ins/outref/nest_err_et2.txt
@@ -34,14 +34,14 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 
 GTM environment initialized within C...
 
-M2: $ZLEVEL = 2
-M2: $STACK = 1
+M2: $ZLEVEL = 1
+M2: $STACK = 0
 M2: $ESTACK = 1
-$stack(1,"PLACE") in divzro3 = +16^divzro3
-$stack(1,"MCODE") in divzro3 =     w !,"$stack(1,""MCODE"") in divzro3 = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro3 = 
+$stack(0,"PLACE") in divzro3 = +19^divzro3
+$stack(0,"MCODE") in divzro3 =     w !,"$stack(0,""MCODE"") in divzro3 = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro3 = 
 
-Illegal-- attempt to divide by zero 150373210,+19^divzro3,%GTM-E-DIVZERO, Attempt to divide by zero 
+Illegal-- attempt to divide by zero 150373210,+22^divzro3,%GTM-E-DIVZERO, Attempt to divide by zero 
 
 Values returned from inmult:
 

--- a/call_ins/outref/nest_err_et3.txt
+++ b/call_ins/outref/nest_err_et3.txt
@@ -34,13 +34,13 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 
 GTM environment initialized within C...
 
-M2: $ZLEVEL = 2
-M2: $STACK = 1
+M2: $ZLEVEL = 1
+M2: $STACK = 0
 M2: $ESTACK = 1
-$stack(1,"PLACE") in divzro4 = +16^divzro4
-$stack(1,"MCODE") in divzro4 =     w !,"$stack(1,""MCODE"") in divzro4 = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro4 = 
- 150373210,+19^divzro4,%GTM-E-DIVZERO, Attempt to divide by zero 
+$stack(0,"PLACE") in divzro4 = +19^divzro4
+$stack(0,"MCODE") in divzro4 =     w !,"$stack(0,""MCODE"") in divzro4 = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro4 = 
+ 150373210,+22^divzro4,%GTM-E-DIVZERO, Attempt to divide by zero 
 
 Values returned from inmult:
 

--- a/call_ins/outref/nest_err_zt.txt
+++ b/call_ins/outref/nest_err_zt.txt
@@ -34,12 +34,12 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 
 GTM environment initialized within C...
 
-M2: $ZLEVEL = 2
-M2: $STACK = 1
+M2: $ZLEVEL = 1
+M2: $STACK = 0
 M2: $ESTACK = 1
-$stack(1,"PLACE") in divzro2 = +16^dvzrozt2
-$stack(1,"MCODE") in divzro2 =     w !,"$stack(1,""MCODE"") in divzro2 = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro2 = 
+$stack(0,"PLACE") in divzro2 = +19^dvzrozt2
+$stack(0,"MCODE") in divzro2 =     w !,"$stack(0,""MCODE"") in divzro2 = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro2 = 
 
 Illegal-- attempt to divide by zero
 Values returned from inmult:

--- a/call_ins/outref/nest_err_zt2.txt
+++ b/call_ins/outref/nest_err_zt2.txt
@@ -34,12 +34,12 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 
 GTM environment initialized within C...
 
-M2: $ZLEVEL = 2
-M2: $STACK = 1
+M2: $ZLEVEL = 1
+M2: $STACK = 0
 M2: $ESTACK = 1
-$stack(1,"PLACE") in divzro3 = +16^dvzrozt3
-$stack(1,"MCODE") in divzro3 =     w !,"$stack(1,""MCODE"") in divzro3 = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro3 = 
+$stack(0,"PLACE") in divzro3 = +19^dvzrozt3
+$stack(0,"MCODE") in divzro3 =     w !,"$stack(0,""MCODE"") in divzro3 = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro3 = 
 
 Illegal-- attempt to divide by zero
 Values returned from inmult:

--- a/call_ins/outref/nest_err_zt3.txt
+++ b/call_ins/outref/nest_err_zt3.txt
@@ -34,13 +34,13 @@ xc_inmult: sizeof(arg_stringp) = 8,	arg_stringp->length = 16
 
 GTM environment initialized within C...
 
-M2: $ZLEVEL = 2
-M2: $STACK = 1
+M2: $ZLEVEL = 1
+M2: $STACK = 0
 M2: $ESTACK = 1
-$stack(1,"PLACE") in divzro4 = +16^dvzrozt4
-$stack(1,"MCODE") in divzro4 =     w !,"$stack(1,""MCODE"") in divzro4 = ",$stack(1,"MCODE")
-$stack(1,"ECODE") in divzro4 = 
- 150373210,+19^dvzrozt4,%GTM-E-DIVZERO, Attempt to divide by zero 
+$stack(0,"PLACE") in divzro4 = +19^dvzrozt4
+$stack(0,"MCODE") in divzro4 =     w !,"$stack(0,""MCODE"") in divzro4 = ",$stack(0,"MCODE")
+$stack(0,"ECODE") in divzro4 = 
+ 150373210,+22^dvzrozt4,%GTM-E-DIVZERO, Attempt to divide by zero 
 
 Values returned from inmult:
 

--- a/call_ins/outref/outref.txt
+++ b/call_ins/outref/outref.txt
@@ -1,3 +1,4 @@
+##SUSPEND_OUTPUT  REPLIC
 PASS from 32args
 PASS from argcnt
 PASS from c_args
@@ -24,10 +25,18 @@ PASS from gtm_cip
 PASS from timers
 PASS from empty_table
 PASS from stack_leak
+PASS from test_rtn_replace
+PASS from test_mprof_hidden_rtn
+PASS from test_ci_z_halt
+PASS from test_ci_zgoto0
 ##SUSPEND_OUTPUT NON_UTF8
 ##SUSPEND_OUTPUT PLATFORM_NO_4BYTE_UTF8
 PASS from unic2m2c2m
 ##ALLOW_OUTPUT PLATFORM_NO_4BYTE_UTF8
 PASS from unimaxstrlen
 ##ALLOW_OUTPUT NON_UTF8
+##SUSPEND_OUTPUT  NON_REPLIC
+##ALLOW_OUTPUT  REPLIC
+PASS from environment
+##ALLOW_OUTPUT  NON_REPLIC REPLIC
 CALL IN tests DONE

--- a/call_ins/outref/test_ci_z_halt.txt
+++ b/call_ins/outref/test_ci_z_halt.txt
@@ -1,0 +1,9 @@
+testcizhalt1: Entered - Driving ^testcizhaltA
+testcizhaltA: Entered -- driving first call-in
+testcizhalt2: Entered - driving HALT now to return to call-in caller
+testcizhaltA: Back in testcizhaltA - driving second call-in
+testcizhalt3: Entered - driving ZHALT now to return to call-in caller
+testcizhaltA: Back in testcizhaltA
+testcizhaltA: Returning
+testcizhalt1: Back in testcizhalt1 - Test complete
+End of test_ci_z_halt subtest

--- a/call_ins/outref/test_ci_zgoto0.txt
+++ b/call_ins/outref/test_ci_zgoto0.txt
@@ -1,0 +1,7 @@
+testcizgoto01: Entered - Driving ^testcizgoto0A
+testcizgoto0A: Entered -- driving first call-in
+testcizgoto02: Entered - driving ZGOTO 0 now to return to call-in caller
+testcizgoto0A: Back in testcizgoto0A
+testcizgoto0A: Returning
+testcizgoto01: Back in testcizgoto01 - Test complete
+End of test_ci_zgoto0 subtest

--- a/call_ins/outref/test_mprof_hidden_rtn.txt
+++ b/call_ins/outref/test_mprof_hidden_rtn.txt
@@ -1,0 +1,18 @@
+Files Created in ##TEST_PATH##:
+Using: ##SOURCE_PATH##/mumps -run GDE
+mumps.gld
+Using: ##SOURCE_PATH##/mupip
+mumps.dat
+testmprofhiddenrtn1: Entered - Driving ^testmprofhiddenrtnA
+testmprofhiddenrtnA: Entered -- driving call-in
+testmprofhiddenrtn2: Entered
+testmprofhiddenrtn2: Returning
+testmprofhiddenrtnA: Back in testmprofhiddenrtnA
+testmprofhiddenrtnA: Returning
+testmprofhiddenrtn1: Back in testmprofhiddenrtn1 - writing out mprof trace and exiting
+testmprofhiddenrtn1: PASS
+testmprofhiddenrtn1: Test complete
+##SOURCE_PATH##/mupip
+##SOURCE_PATH##/mupip integ -REG *
+No errors detected by integ.
+End of test_mprof_hidden_rtn subtest

--- a/call_ins/outref/test_rtn_replace.txt
+++ b/call_ins/outref/test_rtn_replace.txt
@@ -1,0 +1,28 @@
+testrtnreplc1: Entered - initialize some vars to play with
+testrtnreplc1: Driving call-in
+testrtnreplcA: Entered -- driving call-in
+testrtnreplc2: Entered - creating alternate testrtnreplcA routine
+testrtnreplc2: ZLINKing new version of ^testrtnreplcA
+testrtnreplc2: Driving replaced ^testrtnreplcA
+testrtnreplcA (replaced): Entered - do some variable play
+testrtnreplcA (replaced): Returning
+testrtnreplc2: Back in testrtnreplc2 -- returning
+testrtnreplcA: Back in testrtnreplcA
+testrtnreplcA: Driving ^testrtnreplc3
+testrtnreplc3: Entered - set 3 (different) var with different values
+testrtnreplc3: Returning
+testrtnreplcA: Use variables to see if l_symtab was corrupted
+testrtnreplcA: Returning
+testrtnreplc1: Back in testrtnreplc1 - variable values:
+a=84
+b=8484
+c=848484
+d=168
+e=7198538256
+f=7199395476
+fn="testrtnreplcA.m"
+rtnname="testrtnreplc2"
+x=-1
+y=0
+z=1
+End of test_rtn_replace subtest

--- a/call_ins/u_inref/32args.csh
+++ b/call_ins/u_inref/32args.csh
@@ -34,4 +34,4 @@ endif
 rm -f  link.map
 #
 args
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/argcnt.csh
+++ b/call_ins/u_inref/argcnt.csh
@@ -41,4 +41,4 @@ endif
 rm -f  link.map
 #
 argcnt_more
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/c_args.csh
+++ b/call_ins/u_inref/c_args.csh
@@ -40,7 +40,7 @@ endif
 rm -f  link.map
 #
 ciargs
-unsetenv $GTMCI
+unsetenv GTMCI
 if (1 == $gtm_test_trigger) then
 	# Since same triggers can be loaded in multiple regions, ignore the runtime disambiguator and count
 	# i.e all of the below are counted as the same trigger "ACCT"

--- a/call_ins/u_inref/ctomctom.csh
+++ b/call_ins/u_inref/ctomctom.csh
@@ -13,6 +13,7 @@
 # ctomctom.csh
 #
 # call in to M from C
+#
 setenv GTMCI cmcm.tab
 cat >> $GTMCI << cmcm.tab
 sqroot: void  sqroot^sqrt2(I:gtm_long_t,I:gtm_long_t)
@@ -28,7 +29,6 @@ endif
 
 rm -f  link1.map
 rm -f squarec.o
-
 
 #
 # external call to C from M
@@ -48,5 +48,5 @@ endif
 rm -f link2.map
 
 cmcm
-unsetenv $GTMCI
-unsetenv $GTMXC
+unsetenv GTMCI
+unsetenv GTMXC

--- a/call_ins/u_inref/ctomtom.csh
+++ b/call_ins/u_inref/ctomtom.csh
@@ -17,8 +17,6 @@ cat >> $GTMCI << cmm.tab
 chngbase: gtm_char_t*  base^base(I:gtm_long_t,I:gtm_long_t,I:gtm_long_t)
 cmm.tab
 #
-#
-
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/ctomtom.c
 $gt_ld_linker $gt_ld_option_output ctmm $gt_ld_options_common ctomtom.o $gt_ld_sysrtns $ci_ldpath$gtm_dist -L$gtm_dist $tst_ld_gtmshr $gt_ld_syslibs >& link.map
 if( $status != 0 ) then
@@ -27,5 +25,5 @@ endif
 rm -f  link.map
 #
 ctmm
-unsetenv $GTMCI
+unsetenv GTMCI
 

--- a/call_ins/u_inref/empty_table.csh
+++ b/call_ins/u_inref/empty_table.csh
@@ -34,4 +34,4 @@ rm -f link.map
 empty_table
 
 # Unset GTMCI.
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/environment.csh
+++ b/call_ins/u_inref/environment.csh
@@ -1,0 +1,66 @@
+#################################################################
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test $VIEW("ENVIRONMENT") under varying environmental conditions (M code, trigger, callin, etc).
+#
+setenv gtm_test_trigger 0	# Disable auto-generated triggers to make our trigger output below more predictable
+source $gtm_tst/com/dbcreate.csh mumps
+#
+# Create a simple trigger to execute our $VIEW() function
+#
+cat << EOF >> environment.trg
+-*
++^A -command=S -xecute="write ""\$VIEW(""""ENVIRONMENT"""")="",\$VIEW(""ENVIRONMENT""),!,""M-Stack follows:"",! zshow ""S"""
+EOF
+#
+# Create simple call-out (aka external call) that wants to do a call-in
+#
+setenv GTMXC drivecirtn.xc
+echo "`pwd`/libdrivecirtn${gt_ld_shl_suffix}" > $GTMXC
+cat >> $GTMXC << EOF
+drivecirtn: void drivecirtn(I:gtm_char_t *)
+EOF
+#
+# Create simple call-in
+#
+setenv GTMCI environci.xc
+cat >> $GTMCI << EOF
+environci: void environci^environment()
+EOF
+#
+# Build shared library to hold the external call in
+#
+$gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/drivecirtn.c
+$gt_ld_shl_linker ${gt_ld_option_output}libdrivecirtn${gt_ld_shl_suffix} $gt_ld_shl_options drivecirtn.o $gt_ld_syslibs >& link1.map
+if (0 != $status) then
+    cat link1.map
+endif
+#
+# Add our trigger to our database (which should replicate over)
+#
+$MUPIP trigger -triggerfile=environment.trg -noprompt
+$gtm_dist/mumps -run environment
+echo
+#
+# Close down replication
+#
+source $gtm_tst/com/dbcheck.csh
+#
+# Locate one additional message in update process log
+#
+echo
+setenv start_time `cat start_time`
+set dlr = '$'
+echo "Looking for message from update process trigger giving value for ${dlr}VIEW(""ENVIRONMENT""):"
+$grep VIEW $SEC_SIDE/RCVR_${start_time}.log.updproc | grep "ENVIRONMENT"
+#
+echo "End of environment subtest"

--- a/call_ins/u_inref/gtm_args.csh
+++ b/call_ins/u_inref/gtm_args.csh
@@ -36,7 +36,7 @@ endif
 rm -f  link.map
 #
 args
-unsetenv $GTMCI
+unsetenv GTMCI
 if (1 == $gtm_test_trigger) then
 	# Since same triggers can be loaded in multiple regions, ignore the runtime disambiguator and count
 	# i.e all of the below are counted as the same trigger "ACCT"

--- a/call_ins/u_inref/gtm_cip.csh
+++ b/call_ins/u_inref/gtm_cip.csh
@@ -27,4 +27,4 @@ endif
 rm -f link1.map
 
 gtm_cip
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/gtm_exit_err.csh
+++ b/call_ins/u_inref/gtm_exit_err.csh
@@ -13,7 +13,7 @@
 # gtm_exit_err.csh
 #
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/gtm_exit.c
-$gt_ld_shl_linker ${gt_ld_option_output}libexit${gt_ld_shl_suffix} $gt_ld_shl_options gtm_exit.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
+$gt_ld_shl_linker ${gt_ld_option_output}libexit${gt_ld_shl_suffix} $gt_ld_shl_options gtm_exit.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
 
 if( $status != 0 ) then
     cat link1.map
@@ -32,16 +32,15 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI err.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^divzro2()
 yy
-unsetenv $GTMCI
-#
 #
 $GTM <<EOF
 Write "Do ^gtmexit",!  Do ^gtmexit
 Halt
 EOF
 unsetenv GTMXC
+unsetenv GTMCI

--- a/call_ins/u_inref/gtm_percent.csh
+++ b/call_ins/u_inref/gtm_percent.csh
@@ -30,4 +30,4 @@ endif
 rm -f link.map
 
 gtmpercent
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/gtmxc_test_types.csh
+++ b/call_ins/u_inref/gtmxc_test_types.csh
@@ -51,7 +51,7 @@ endif
 rm -f  link.map
 #
 gtmxc_test_types
-unsetenv $GTMCI
+unsetenv GTMCI
 #$gtm_tst/com/dbcheck.csh -extract
 
 

--- a/call_ins/u_inref/lngargs.csh
+++ b/call_ins/u_inref/lngargs.csh
@@ -26,7 +26,7 @@ endif
 rm -f  link.map
 #
 lngargs
-unsetenv $GTMCI
+unsetenv GTMCI
 
 
 

--- a/call_ins/u_inref/maxnstlvl.csh
+++ b/call_ins/u_inref/maxnstlvl.csh
@@ -49,6 +49,6 @@ endif
 rm -f link2.map
 
 dmain
-unsetenv $GTMCI
-unsetenv $GTMXC_xcall
+unsetenv GTMCI
+unsetenv GTMXC_xcall
 

--- a/call_ins/u_inref/maxstrlen.csh
+++ b/call_ins/u_inref/maxstrlen.csh
@@ -19,7 +19,6 @@ cat >> $GTMCI << aa
 maxstr: void  mmaxstr^mmaxstr(I:gtm_char_t*)
 aa
 #
-#
 $gt_cc_compiler $gtt_cc_shl_options $gtm_tst/$tst/inref/cmaxstrlen.c -I$gtm_dist >& comp.log
 $gt_ld_linker $gt_ld_option_output cmaxstrlen $gt_ld_options_common cmaxstrlen.o $gt_ld_sysrtns $ci_ldpath$gtm_dist -L$gtm_dist $tst_ld_gtmshr $gt_ld_syslibs >& link.map
 if( $status != 0 ) then
@@ -29,5 +28,5 @@ rm -f  link.map
 #
 #run cmaxstrlen
 cmaxstrlen
-unsetenv $GTMCI
+unsetenv GTMCI
 

--- a/call_ins/u_inref/multi_gtm_init.csh
+++ b/call_ins/u_inref/multi_gtm_init.csh
@@ -18,8 +18,6 @@ cat >> $GTMCI << cmm.tab
 square:gtm_long_t*  squar^square(I:gtm_long_t)
 cmm.tab
 #
-#
-
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/multi_init.c
 $gt_ld_linker $gt_ld_option_output multi $gt_ld_options_common multi_init.o $gt_ld_sysrtns $ci_ldpath$gtm_dist -L$gtm_dist $tst_ld_gtmshr $gt_ld_syslibs >& link.map
 if( $status != 0 ) then
@@ -28,5 +26,5 @@ endif
 rm -f  link.map
 #
 multi
-unsetenv $GTMCI
+unsetenv GTMCI
 

--- a/call_ins/u_inref/multlab.csh
+++ b/call_ins/u_inref/multlab.csh
@@ -30,4 +30,4 @@ rm -f  link.map
 #
 echo "Two calls both should go to Greaterthan31charlabelshouldnot^multlabm"
 multlab
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/nest_err.csh
+++ b/call_ins/u_inref/nest_err.csh
@@ -12,7 +12,7 @@
 #  nesterr_err.csh - nested calls - M1 -> C -> M2, M2 with errors, $ET, $ZT default values
 #
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/nesterr.c
-$gt_ld_shl_linker ${gt_ld_option_output}libnesterr${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
+$gt_ld_shl_linker ${gt_ld_option_output}libnesterr${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
 
 if( $status != 0 ) then
     cat link1.map
@@ -30,16 +30,16 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI ctom.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^divzro()
 yy
-unsetenv $GTMCI
 #
 #
 $GTM <<EOF
 Write "Do ^nsterror",!  Do ^nsterror
 Halt
 EOF
+unsetenv GTMCI
 unsetenv GTMXC

--- a/call_ins/u_inref/nest_err_et.csh
+++ b/call_ins/u_inref/nest_err_et.csh
@@ -10,10 +10,10 @@
 #								#
 #################################################################
 #
-#	nest_err_et.csh 
+#	nest_err_et.csh
 #
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/nesterr.c
-$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
+$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
 if( $status != 0 ) then
     cat link1.map
 endif
@@ -30,12 +30,11 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI ctom.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^divzro2()
 yy
-unsetenv $GTMCI
 #
 #
 $GTM <<EOF
@@ -43,3 +42,4 @@ Write "Do ^nesterr1",!  Do ^nesterr1
 Halt
 EOF
 unsetenv GTMXC
+unsetenv GTMCI

--- a/call_ins/u_inref/nest_err_et2.csh
+++ b/call_ins/u_inref/nest_err_et2.csh
@@ -11,9 +11,9 @@
 #################################################################
 #
 # nest_err_et2.csh
-#       
+#
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/nesterr.c
-$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
+$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
 
 if( $status != 0 ) then
     cat link1.map
@@ -32,16 +32,15 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI ctom.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^divzro3()
 yy
-unsetenv $GTMCI
-#
 #
 $GTM <<EOF
 Write "Do ^nestet1",!  Do ^nestet1
 Halt
 EOF
 unsetenv GTMXC
+unsetenv GTMCI

--- a/call_ins/u_inref/nest_err_et3.csh
+++ b/call_ins/u_inref/nest_err_et3.csh
@@ -11,10 +11,9 @@
 #################################################################
 #
 # nest_err_et3.csh
-#       
+#
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/nesterr.c
-$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
-
+$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
 if( $status != 0 ) then
     cat link1.map
 endif
@@ -32,12 +31,11 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI ctom.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^divzro4()
 yy
-unsetenv $GTMCI
 #
 #
 $GTM <<EOF
@@ -45,3 +43,4 @@ Write "Do ^nestet2",!  Do ^nestet2
 Halt
 EOF
 unsetenv GTMXC
+unsetenv GTMCI

--- a/call_ins/u_inref/nest_err_zt.csh
+++ b/call_ins/u_inref/nest_err_zt.csh
@@ -12,7 +12,7 @@
 #	nest_er_zt.csh
 #
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/nesterr.c
-$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
+$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
 
 if( $status != 0 ) then
     cat link1.map
@@ -30,12 +30,11 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI ctom.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^dvzrozt2()
 yy
-unsetenv $GTMCI
 #
 #
 $GTM <<EOF
@@ -43,3 +42,4 @@ Write "Do ^nesterzt",!  Do ^nesterzt
 Halt
 EOF
 unsetenv GTMXC
+unsetenv GTMCI

--- a/call_ins/u_inref/nest_err_zt2.csh
+++ b/call_ins/u_inref/nest_err_zt2.csh
@@ -10,10 +10,10 @@
 #								#
 #################################################################
 #
-#	nest_err_zt2.csh 
-#       
+#	nest_err_zt2.csh
+#
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/nesterr.c
-$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
+$gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
 
 if( $status != 0 ) then
     cat link1.map
@@ -32,12 +32,11 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI ctom.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^dvzrozt3()
 yy
-unsetenv $GTMCI
 #
 #
 $GTM <<EOF
@@ -45,3 +44,4 @@ Write "Do ^nestzt1",!  Do ^nestzt1
 Halt
 EOF
 unsetenv GTMXC
+unsetenv GTMCI

--- a/call_ins/u_inref/nest_err_zt3.csh
+++ b/call_ins/u_inref/nest_err_zt3.csh
@@ -11,7 +11,7 @@
 #################################################################
 #
 #	nest_err_zt2.csh
-#       
+#
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/nesterr.c
 $gt_ld_shl_linker ${gt_ld_option_output}libnesterr1${gt_ld_shl_suffix} $gt_ld_shl_options nesterr.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map 
 
@@ -31,16 +31,15 @@ inmult:		void	xc_inmult(I:xc_float_t *, I:xc_double_t *, I:xc_char_t *, I:xc_cha
 xx
 #
 # call_in
-# 
+#
 setenv GTMCI ctom.tab
 cat >> $GTMCI << yy
 divbyzro:  void ^dvzrozt4()
 yy
-unsetenv $GTMCI
-#
 #
 $GTM <<EOF
 Write "Do ^nestzt2",!  Do ^nestzt2
 Halt
 EOF
 unsetenv GTMXC
+unsetenv GTMCI

--- a/call_ins/u_inref/stack_leak.csh
+++ b/call_ins/u_inref/stack_leak.csh
@@ -39,4 +39,4 @@ rm -f link.map
 stack_leak >&! stack_leak.out
 
 # Unset GTMCI.
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/test_ci_z_halt.csh
+++ b/call_ins/u_inref/test_ci_z_halt.csh
@@ -1,0 +1,71 @@
+#################################################################
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test condition that when:
+#   1. A routine "artn" is on the M call stack.
+#   2. That routine or some subsequent routine does an external call.
+#   3. The external call does a call-in back into M mode.
+#   4. The call-in does a HALT which should return immediately to the caller.
+#   5. This is repeated with the main routine driving another callin that
+#      instead does a ZHALT and verifies we again return to the caller instead
+#      of actually halting.
+#
+# Note this test fails with any version previous to V63002_R110.
+# (This test is a stripped down version of test_rtn_replace)
+#
+
+#
+# Build shared library to hold the external call in
+#
+$gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/drivecirtn.c
+$gt_ld_shl_linker ${gt_ld_option_output}libdrivecirtn${gt_ld_shl_suffix} $gt_ld_shl_options drivecirtn.o $gt_ld_syslibs >& link1.map
+if (0 != $status) then
+    cat link1.map
+endif
+#
+# Create simple call-out (aka external call) that wants to do a call-in
+#
+setenv GTMXC drivecirtn.xc
+echo "`pwd`/libdrivecirtn${gt_ld_shl_suffix}" > $GTMXC
+cat >> $GTMXC << EOF
+drivecirtn: void drivecirtn(I:gtm_char_t *)
+EOF
+#
+# Create simple call-in to test routine replacement
+#
+setenv GTMCI testcizhalt.xc
+cat >> $GTMCI << EOF
+testcizhalt2: void testcizhalt2()
+testcizhalt3: void testcizhalt3()
+EOF
+#
+# Create our "artn" (with a more meaningful name)
+#
+setenv RTNA testcizhaltA.m
+cat >> $RTNA << EOF
+testcizhaltA
+    write "testcizhaltA: Entered -- driving first call-in",!
+    set rtnname="testcizhalt2"
+    do &drivecirtn(.rtnname)
+    write "testcizhaltA: Back in testcizhaltA - driving second call-in",!
+    set rtnname="testcizhalt3"
+    do &drivecirtn(.rtnname)
+    write "testcizhaltA: Back in testcizhaltA",!
+    write "testcizhaltA: Returning",!
+    quit
+EOF
+#
+# Drive main test
+#
+$gtm_dist/mumps -run testcizhalt1
+#
+echo "End of test_ci_z_halt subtest"

--- a/call_ins/u_inref/test_ci_zgoto0.csh
+++ b/call_ins/u_inref/test_ci_zgoto0.csh
@@ -1,0 +1,63 @@
+#################################################################
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test condition that when:
+#   1. A routine "artn" is on the M call stack.
+#   2. That routine or some subsequent routine does an external call.
+#   3. The external call does a call-in back into M mode.
+#   4. The call-in does a ZGOTO 0 which should return immediately to the caller.
+#
+# (This test is a stripped down version of test_rtn_replace)
+#
+
+#
+# Build shared library to hold the external call in
+#
+$gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gt_cc_option_DDEBUG $gt_cc_option_debug $gtm_tst/$tst/inref/drivecirtn.c
+$gt_ld_shl_linker ${gt_ld_option_output}libdrivecirtn${gt_ld_shl_suffix} $gt_ld_shl_options drivecirtn.o $gt_ld_syslibs >& link1.map
+if (0 != $status) then
+    cat link1.map
+endif
+#
+# Create simple call-out (aka external call) that wants to do a call-in
+#
+setenv GTMXC drivecirtn.xc
+echo "`pwd`/libdrivecirtn${gt_ld_shl_suffix}" > $GTMXC
+cat >> $GTMXC << EOF
+drivecirtn: void drivecirtn(I:gtm_char_t *)
+EOF
+#
+# Create simple call-in to test routine replacement
+#
+setenv GTMCI testcizgoto0.xc
+cat >> $GTMCI << EOF
+testcizgoto02: void testcizgoto02()
+EOF
+#
+# Create our "artn" (with a more meaningful name)
+#
+setenv RTNA testcizgoto0A.m
+cat >> $RTNA << EOF
+testcizgoto0A
+    write "testcizgoto0A: Entered -- driving first call-in",!
+    set rtnname="testcizgoto02"
+    do &drivecirtn(.rtnname)
+    write "testcizgoto0A: Back in testcizgoto0A",!
+    write "testcizgoto0A: Returning",!
+    quit
+EOF
+#
+# Drive main test
+#
+$gtm_dist/mumps -run testcizgoto01
+#
+echo "End of test_ci_zgoto0 subtest"

--- a/call_ins/u_inref/test_mprof_hidden_rtn.csh
+++ b/call_ins/u_inref/test_mprof_hidden_rtn.csh
@@ -1,0 +1,72 @@
+#################################################################
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test condition that when:
+#   1. M-Profiling is activated.
+#   2. A routine "artn" is on the M call stack.
+#   4. That routine or some subsequent routine does an external call.
+#   4. The external call does a call-in back into M mode.
+#   5. The call-in pretty much just returns (just needed something to run here)
+#   6. Once back in the main routine do an analysis of the collected M-Profile trace data to
+#      detect where M-Profiling had trouble locating the routine behind the the call-in base
+#      frame and the effect that has on the data returned. See testmprofhiddenrtn.m for details.
+#
+# Note this test fails with any version previous to V63002_R110.
+# (This test is a stripped down version of test_rtn_replace)
+#
+
+unsetenv gtm_trace_gbl_name			# Unset to prevent interaction with our own enabling of MPROFiling
+source $gtm_tst/com/dbcreate.csh mumps 1	# For mprof to use to dump its info (not used by test otherwise)
+#
+# Build shared library to hold the external call in
+#
+$gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gt_cc_option_DDEBUG $gt_cc_option_debug $gtm_tst/$tst/inref/drivecirtn.c
+$gt_ld_shl_linker ${gt_ld_option_output}libdrivecirtn${gt_ld_shl_suffix} $gt_ld_shl_options drivecirtn.o $gt_ld_syslibs >& link1.map
+if (0 != $status) then
+    cat link1.map
+endif
+#
+# Create simple call-out (aka external call) that wants to do a call-in
+#
+setenv GTMXC drivecirtn.xc
+echo "`pwd`/libdrivecirtn${gt_ld_shl_suffix}" > $GTMXC
+cat >> $GTMXC << EOF
+drivecirtn: void drivecirtn(I:gtm_char_t *)
+EOF
+#
+# Create simple call-in to test routine replacement
+#
+setenv GTMCI testmprofhiddenrtn2.xc
+cat >> $GTMCI << EOF
+testmprofhiddenrtn2: void testmprofhiddenrtn2()
+EOF
+#
+# Create our "artn" (with a more meaningful name)
+#
+setenv RTNA testmprofhiddenrtnA.m
+cat >> $RTNA << EOF
+testmprofhiddenrtnA
+    write "testmprofhiddenrtnA: Entered -- driving call-in",!
+    set rtnname="testmprofhiddenrtn2"
+    do &drivecirtn(.rtnname)
+    write "testmprofhiddenrtnA: Back in testmprofhiddenrtnA",!
+    write "testmprofhiddenrtnA: Returning",!
+    quit
+EOF
+#
+# Drive main test
+#
+$gtm_dist/mumps -run testmprofhiddenrtn1
+#
+source $gtm_tst/com/dbcheck.csh
+#
+echo "End of test_mprof_hidden_rtn subtest"

--- a/call_ins/u_inref/test_rtn_replace.csh
+++ b/call_ins/u_inref/test_rtn_replace.csh
@@ -1,0 +1,78 @@
+#################################################################
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test condition that when:
+#   1. A routine "artn" is on the M call stack.
+#   2. That routine or some subsequent routine does an external call.
+#   3. The external call does a call-in back into M mode.
+#   4. A new version of "artn" created and driven.
+#   5. The zlput_rname() routine looks back through the stack to see if a version
+#      of "artn" exists on the stack. V63001A_R100 and earlier don't find the routine
+#      as the search stops at the call-in boundary. This can cause the original artn
+#      to explode most spectacularly. Post V63001A_R100 should find the routine and
+#      "fork" the routine so the old routine stays around until it pops off the stack
+#      while the new routine takes its place for all other matters.
+#
+# Test logic:
+#   - If this test completes without a fatal exit producing a core file, then the test
+#     passes.
+#   - Else it fails. The presence of the core itself will result in test failure.
+#
+# Note this test fails with any version previous to V63002_R110.
+#
+
+#
+# Build shared library to hold the external call in
+#
+$gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gt_cc_option_DDEBUG $gt_cc_option_debug $gtm_tst/$tst/inref/drivecirtn.c
+$gt_ld_shl_linker ${gt_ld_option_output}libdrivecirtn${gt_ld_shl_suffix} $gt_ld_shl_options drivecirtn.o $gt_ld_syslibs >& link1.map
+if (0 != $status) then
+    cat link1.map
+endif
+#
+# Create simple call-out (aka external call) that wants to do a call-in
+#
+setenv GTMXC drivecirtn.xc
+echo "`pwd`/libdrivecirtn${gt_ld_shl_suffix}" > $GTMXC
+cat >> $GTMXC << EOF
+drivecirtn: void drivecirtn(I:gtm_char_t *)
+EOF
+#
+# Create simple call-in to test routine replacement
+#
+setenv GTMCI testrtnreplc2.xc
+cat >> $GTMCI << EOF
+testrtnreplc2: void testrtnreplc2()
+EOF
+#
+# Create our "artn" (with a more meaningful name)
+#
+setenv RTNA testrtnreplcA.m
+cat >> $RTNA << EOF
+testrtnreplcA
+    write "testrtnreplcA: Entered -- driving call-in",!
+    set rtnname="testrtnreplc2"
+    do &drivecirtn(.rtnname)
+    write "testrtnreplcA: Back in testrtnreplcA",!
+    write "testrtnreplcA: Driving ^testrtnreplc3",!
+    do ^testrtnreplc3
+    write "testrtnreplcA: Use variables to see if l_symtab was corrupted",!
+    set d=a*2,e=b*c,f=a+b+c+d+e   ; Some variable play to access some vars that went inaccessible if routine was replaced
+    write "testrtnreplcA: Returning",!
+    quit
+EOF
+#
+# Drive main test
+#
+$gtm_dist/mumps -run testrtnreplc1
+#
+echo "End of test_rtn_replace subtest"

--- a/call_ins/u_inref/timers.csh
+++ b/call_ins/u_inref/timers.csh
@@ -36,4 +36,4 @@ rm -f link.map
 timers
 
 # Unset GTMCI.
-unsetenv $GTMCI
+unsetenv GTMCI

--- a/call_ins/u_inref/unic2m2c2m.csh
+++ b/call_ins/u_inref/unic2m2c2m.csh
@@ -56,5 +56,5 @@ rm -f link2.map
 
 cmcm_uni
 cd ..
-unsetenv $GTMCI
-unsetenv $GTMXC
+unsetenv GTMCI
+unsetenv GTMXC

--- a/call_ins/u_inref/unimaxstrlen.csh
+++ b/call_ins/u_inref/unimaxstrlen.csh
@@ -67,5 +67,5 @@ if ($?gtm_custom_errors_save_umsl) then
 endif
 #
 cd ..
-unsetenv $GTMCI
+unsetenv GTMCI
 

--- a/call_ins/u_inref/xc_test_types.csh
+++ b/call_ins/u_inref/xc_test_types.csh
@@ -51,7 +51,7 @@ endif
 rm -f  link.map
 #
 xc_test_types
-unsetenv $GTMCI
+unsetenv GTMCI
 #$gtm_tst/com/dbcheck.csh -extract
 
 

--- a/com/SUITE
+++ b/com/SUITE
@@ -21,6 +21,7 @@ basic E
 basic E REPLIC
 call_ins  L
 call_ins  E
+call_ins  E REPLIC
 compil L
 compil E
 compil E REPLIC

--- a/v63000/inref/gtm8431.m
+++ b/v63000/inref/gtm8431.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2015-2016 Fidelity National Information		;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.	     	  	     			;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -17,15 +20,12 @@ gtm8431	;Validate $TEXT() of ^GTM$DMOD or ^GTM$CI returns an empty string not pr
 	set $ecode="",$etrap="do ^incretrap"
 	do nogbls^incretrap
 	if $length($text(^GTM$DMOD)),$increment(cnt) xecute ops
-	if $length($text(^GTM$CI)),$increment(cnt) xecute ops
-	for rtn="^GTM$DMOD","^GTM$CI" if $length($text(@rtn)),$increment(cnt) xecute ops
+	for rtn="^GTM$DMOD" if $length($text(@rtn)),$increment(cnt) xecute ops
 	set incretrap("EXPECT")="RPARENMISSING",incretrap("NODISP")=1
-	for rtn="^GTM$DMO","^GTM$DMODS","^GTM$C","^GTM$C" do
+	for rtn="^GTM$DMO","^GTM$DMODS" do
 	. write $text(@rtn)
 	write !,$select('$get(cnt):"PASS",1:"FAIL")," from ",$text(+0),!
 	quit
 	; the lines below should all issue compiler warnings - no need to execute them
 	write $text(^GTM$DMO)
 	write $text(^GTM$DMODS)
-	write $text(^GTM$C)
-	write $text(^GTM$CIS)

--- a/v63000/outref/gtm8431.txt
+++ b/v63000/outref/gtm8431.txt
@@ -1,16 +1,8 @@
 		write $text(^GTM$DMO)
 		                ^-----
-		At column 18, line 28, source module ##IN_TEST_PATH##/inref/gtm8431.m
-%GTM-E-RPARENMISSING, Right parenthesis expected
-		write $text(^GTM$DMODS)
-		                ^-----
-		At column 18, line 29, source module ##IN_TEST_PATH##/inref/gtm8431.m
-%GTM-E-RPARENMISSING, Right parenthesis expected
-		write $text(^GTM$C)
-		                ^-----
 		At column 18, line 30, source module ##IN_TEST_PATH##/inref/gtm8431.m
 %GTM-E-RPARENMISSING, Right parenthesis expected
-		write $text(^GTM$CIS)
+		write $text(^GTM$DMODS)
 		                ^-----
 		At column 18, line 31, source module ##IN_TEST_PATH##/inref/gtm8431.m
 %GTM-E-RPARENMISSING, Right parenthesis expected


### PR DESCRIPTION
…s affected by callinperf changes

New subtests added:

1. environment subtest (replication) - tests new $VIEW("ENVIRONMENT") under various environmental conditions
   such as M-code, trigger, callin and such in both M runtime and update process environments.
2. test_rtn_replace subtest - When a routine is on the stack and is re-linked, zlput_rname() is what looks
   to see if the routine is on the stack or not. But prior to V63002_R110, it was not going back past a call-in
   base frame so if the routine was on the stack prior to that, it was not found and bad things could happen.
   This subtest tests that condition and verifies it works (test fails with a core file prior to V63002_R110).
   Note this test uses VIEW "LINK":"RECURSIVE" but that it not required to encounter the flaw. It just makes
   the flaw easier to detect and cause an issue in a test situation.
3. test_mprof_hidden_rtn subtest - Similar to test_rtn_replace above, M-Profiling also looks back in the stack
   looking for routines to get informating from them. When not found due to being blocked by the call-in base
   frame, the information M-Profiling returns is compromised. Though not as spectacular as a core failure, this
   test too fails on V63002_R110 due to bad information generated.
4. test_ci_z_halt subtest - Pre V63002_R110 versions did a real halt for [Z]HALT commands done in a call-in
   environment. In V63002_R110 this was changed to return to the call-in caller with ZHALT supplying the
   return code. This subtest verifies that the return happens correctly.
5. test_ci_zgoto0 subtest - In V63002_R110 the methodology of the zgoto 0 return was changed. It used to
   unwind back to the call-in base frame and engage the ci_ret_code_exit routine which did a longjmp(). The
   new support in V63002_R110 does not return that way any more. It instead returns to gtm_levl_ret_code
   like all the other returns from call_in routines. This subtest just verifies that is working-as-redesigned.

Files added/changed for new subtests:

call_ins/com/SUITE - add replication invocation for call_ins/environment.

call_ins/inref/drivecirtn.c - Utility external call that drives a call-in routine specified by argument.

call_ins/inref/environci.c - external call that does call-in to environci^environment.

call_ins/inref/environment.m - main driver routine plus callin entry point for $VIEW("ENVIRONMENT") testing.

call_ins/inref/testcizgoto01.m - main driver routine for test_ci_zgoto0 subtest

call_ins/inref/testcizgoto02.m - routine driven by call-in in test_ci_zgoto0 subtest

call_ins/inref/testcizhalt1.m - main driver routine for test_ci_z_halt

call_ins/inref/testcizhalt2.m - routine driven by call-in in test_ci_z_halt that does a HALT

call_ins/inref/testcizhalt3.m - routine driven by call-in in test_ci_z_halt that does a ZHALT

call_ins/inref/testmprofhiddenrtn1.m - main driver routine for test_mprof_hidden_rtn

call_ins/inref/testmprofhiddenrtn2.m - routine driven by call-in in test_mprof_hidden_rtn

call_ins/inref/testrtnreplc1.m - main driver routine for test_rtn_replace

call_ins/inref/testrtnreplc2.m - routine drive by call-in in test_rtn_replace

call_ins/inref/testrtnreplc3.m - Simple routine driven to test that a routine CAN be driven from a replaced routine

call_ins/instream.csh/call_ins/instream.csh
  1. Add environment subtest to test $VIEW("ENVIRONMENT") in various situations (replication test)
  2. Add test_rtn_replace subtest to verify routine on stack prior to call-in that gets replaced works correctly
  3. Add test_mprof_hidden_rtn subtest to verify routine on stack prior to call-in can be located in M-Profiling
  4. Add test_ci_z_halt subtest to verify [Z]HALT commands return to caller rather than actually halting
  5. Add test_ci_zgoto0 subtest to verify ZGOTO 0 returns to caller properly

call_ins/outref/outref.txt - Add entries for 5 tests added to instream.csh.

call_ins/outref/environment.txt
call_ins/outref/test_ci_z_halt.txt
call_ins/outref/test_ci_zgoto0.txt
call_ins/outref/test_mprof_hidden_rtn.txt
call_ins/outref/test_rtn_replace.txt
  1. Added references files for each of the added tests

call_ins/u_inref/test_ci_z_halt.csh
call_ins/u_inref/test_ci_zgoto0.csh
call_ins/u_inref/test_mprof_hidden_rtn.csh
call_ins/u_inref/test_rtn_replace.csh
call_ins/u_inref/environment.csh
  1. Added driver scripts for each of the new tests
  Note: Once changes are made such that call-ins can be done in TP, the environment test should be modified to
  drive the same external call we currently drive only on the primary side that then does a call back in and drives
  $VIEW("ENVIRONMENT").

Files modified for previous subtests:

call_ins/inref/divzro.m
call_ins/inref/divzro2.m
call_ins/inref/divzro3.m
call_ins/inref/divzro4.m
call_ins/inref/dvzrozt.m
call_ins/inref/dvzrozt2.m
call_ins/inref/dvzrozt3.m
call_ins/inref/dvzrozt4.m
  1. All of the above M routines were modified to get info for stack level 0 instead of stack
     level 1 due to callins now starting with a stack level 1 lower than previously.

call_ins/inref/gtmxc_test_types.c
  1. Converted to use gtm_cip() instead of gtm_ci() for one test to test gtm_cip().

call_ins/outref/c_args.txt
call_ins/outref/gtm_args.txt
  1. Reduce levels by one due to level start change with this project.

call_ins/outref/gtm_exit_err.txt
  1. Reduce levels by one due to level start change with this project.
  2. Modified to get info for stack level 0 instead of stack level 1 due to callins now starting
     with a stack level 1 lower than previously.

call_ins/outref/maxnstlvl.txt
  1. Remove GTM$CI stack level
  2. Add full stack and new call in level entry indicator.

call_ins/outref/nest_err.txt
call_ins/outref/nest_err_et.txt
call_ins/outref/nest_err_et2.txt
call_ins/outref/nest_err_et3.txt
call_ins/outref/nest_err_zt.txt
call_ins/outref/nest_err_zt2.txt
call_ins/outref/nest_err_zt3.txt
  1. Reduce levels by one due to level start change with this project.
  2. Modified to get info for stack level 0 instead of stack level 1 due to callins now starting
     with a stack level 1 lower than previously.

call_ins/u_inref/ctomctom.csh
call_ins/u_inref/ctomtom.csh
  1. Correct the unsetenv statements to not include the '$' of the envvar being unset.

v63000/inref/gtm8431.m
  - Remove references to GTM$CI and variations as it is nothing special now.

v63000/outref/gtm8431.txt
  - Remove output related to GTM$CI as it no longer exists.

Modified the environment subtest to use generalized drivecirtn instead of its subtest-specific call-in driver.

Disable MPROF tracing from the test system as that interfers with the test_mprof_hidden_rtn subtest

General changes to retrofit new subtests back to new T63000A base. Also fixed all the statements of the
sort "unsetenv $envvar" which should of course not have the '$' in it. Fixing these introduced some
errors in some tests so the unsetenv was moved to the end of the test where it should be.

Re-add a change that got lost in the rebase that fixes an error in the environment subtest