### PR TITLE
[#59] Test changes for call-ins changes plus Simple API changes

### DIFF
--- a/aliaslv/outref/alsmisctests.txt
+++ b/aliaslv/outref/alsmisctests.txt
@@ -19,9 +19,9 @@ Test : PASSED
 -------------------------------------------------------
 Test that reference counts are properly maintained in case of a NOTEXTRINSIC error (from a QUIT *)
 LV_CREF of a = 0
-150374450,funcals+2^alsrefcnt1,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
-150374450,funcals+2^alsrefcnt1,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
-150374450,funcals+2^alsrefcnt1,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+150374450,funcals+2^alsrefcnt1,%GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
+150374450,funcals+2^alsrefcnt1,%GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
+150374450,funcals+2^alsrefcnt1,%GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 LV_CREF of a = 0
 a=3
 i=3

--- a/call_ins/inref/drivecirtn.c
+++ b/call_ins/inref/drivecirtn.c
@@ -14,7 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "ydbxc_types.h"
+#include "libyottadb.h"
 
 #define ERRBUF_SIZE	1024
 

--- a/call_ins/inref/drivecirtn.c
+++ b/call_ins/inref/drivecirtn.c
@@ -14,30 +14,30 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "gtmxc_types.h"
+#include "ydbxc_types.h"
 
 #define ERRBUF_SIZE	1024
 
 /* Routine to take the name of an M routine as an argument and invoke it via a call-in. Probably not useful in
  * real world applications but makes writing test cases for call-ins much easier.
  */
-gtm_status_t drivecirtn(gtm_int_t count, gtm_char_t *rtnname)
+ydb_status_t drivecirtn(ydb_int_t count, ydb_char_t *rtnname)
 {
-	gtm_status_t		status;
+	ydb_status_t		status;
 	char			errbuf[ERRBUF_SIZE];
 
-	status = gtm_init();
+	status = ydb_init();
 	if (status)
 	{
-		gtm_zstatus(errbuf, ERRBUF_SIZE);
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
 		printf("%s\n", errbuf);
 		fflush(stdout);
 		return 0;
 	}
-	status = gtm_ci(rtnname);
+	status = ydb_ci(rtnname);
 	if (status)
 	{
-		gtm_zstatus(errbuf, ERRBUF_SIZE);
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
 		printf("%s\n", errbuf);
 		fflush(stdout);
 		return 0;

--- a/call_ins/inref/testcizhalt3.m
+++ b/call_ins/inref/testcizhalt3.m
@@ -14,6 +14,6 @@
 ;
 testcizhalt3
 	new $etrap
-	set $etrap="write ""testcizhalt3: ** Error** : "",$zstatus,!,""Aborting testcizhalt3"",!"
-	write "testcizhalt3: Entered - driving ZHALT now to return to call-in caller",!
-	zhalt 1		     ; Note if any rc but 0 or 1, intoduces a blank line in reference file
+	set $etrap="write ""testcizhalt3: ** Error caught ** : "",$zstatus,!,""Aborting testcizhalt3"",! set $ecode="""" quit"
+	write "testcizhalt3: Entered - driving ZHALT now to return to call-in caller (expect NOTEXTRINSIC error)",!
+	zhalt 42	     ; Not expecting a return value - this will drive an error

--- a/call_ins/inref/testcizhaltrc.m
+++ b/call_ins/inref/testcizhaltrc.m
@@ -1,0 +1,49 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; See test_ci_z_halt_rc.csh for a description of this test
+;
+
+;
+; Entry point that expects to return an integer value that doesn't get set due to how we exit (in most cases).
+;
+testcizhaltrcint(haltmethod)
+	halt:(1=haltmethod)
+	zhalt:(2=haltmethod) 42
+	zgoto:(3=haltmethod) 0
+	quit:(4=haltmethod)
+	write "testcihaltrcint: Invalid value for haltmethod parameter: ",haltmethod,! hang .3 ; allow to flush
+	quit 24
+
+;
+; Entry point that expects to return a string value that doesn't get set due to how we exit (in most cases).
+;
+testcizhaltrcstr(haltmethod)
+	halt:(1=haltmethod)
+	zhalt:(2=haltmethod) 42
+	zgoto:(3=haltmethod) 0
+	quit:(4=haltmethod)
+	write "testcihaltrcstr: Invalid value for haltmethod parameter: ",haltmethod,! hang .3 ; allow to flush
+	quit "24 is NOT the answer"
+
+;
+; Entry point to test whether we detect missing formallist or not with call-ins
+;
+testcizhaltnoargs
+	write "Made it successfully to testcizhaltnoargs^",$text(+0)," but should have received FMLLSTMISSING",! hang .3
+	halt
+
+;
+; Entry point to test what happens when we quit with a value when none is expected
+;
+testcizhaltnoretval(retint)
+	quit $select(retint:43,1:"x43")

--- a/call_ins/inref/testcizhaltrcmain.c
+++ b/call_ins/inref/testcizhaltrcmain.c
@@ -1,0 +1,206 @@
+/****************************************************************
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ydbxc_types.h"
+
+#define ERRBUF_SIZE	1024
+
+enum {
+	useHALT = 1,
+	useZHALT,
+	useZGOTO0,
+	useQUITretval
+};
+
+/*
+ * See test_ci_z_halt_rc.csh for test description. Series of call-ins that terminate in various ways. We are testing to make sure
+ * they termination in an acceptable fashion (i.e. lack of explosions and correct errors generated). Note the return value is
+ * pre-set before each call so we can see under which conditions the return value is being left unset.
+ */
+int main(void)
+{
+	ydb_status_t		status;
+	ydb_int_t		retintval;
+	ydb_string_t		retstrval;
+	char			errbuf[ERRBUF_SIZE];
+	char			retbuf[32];
+
+	status = ydb_init();		/* Initialize call-in environment */
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+		return 0;
+	}
+
+	/* First is a series of integer return value tests */
+
+	printf("main: Initializing return value to -99 for HALT test\n");
+	retintval = -99;
+	status = ydb_ci("testcizhaltrcint", &retintval, useHALT);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After HALT, return value is %d\n\n", retintval);
+
+	printf("main: Initializing return value to -99 for ZHALT test\n");
+	retintval = -99;
+	status = ydb_ci("testcizhaltrcint", &retintval, useZHALT);
+	if (status)
+	{
+		printf("Return code: %d\n", status);
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After ZHALT, return value is %d\n\n", retintval);
+
+	printf("main: Initializing return value to -99 for ZGOTO 0 test\n");
+	retintval = -99;
+	status = ydb_ci("testcizhaltrcint", &retintval, useZGOTO0);
+	if (status)
+	{
+		printf("Return code: %d\n", status);
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After ZGOTO 0, return value is %d\n\n", retintval);
+
+	printf("main: Initializing return value to -99 for QUIT with no return value (but one expected) test\n");
+	retintval = -99;
+	status = ydb_ci("testcizhaltrcint", &retintval, useQUITretval);
+	if (status)
+	{
+		printf("Return code: %d\n", status);
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After QUIT with no return value (but one expected), return value is %d\n\n", retintval);
+
+	printf("main: Setting up for QUIT with (an unexpected integer) return value test\n");
+	status = ydb_ci("testcizhaltnoretv",1);
+	if (status)
+	{
+		printf("Return code: %d\n", status);
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: Return from QUIT with (an unexpected integer) return value\n\n");
+
+	/* Now the same treatment for a string return */
+
+	printf("main: Initializing return value to 'snarf' for the HALT test\n");
+	retstrval.address = retbuf;
+	strcpy(retbuf, "snarf");
+	retstrval.length = sizeof("snarf") - 1;
+	status = ydb_ci("testcizhaltrcstr", &retstrval, useHALT);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After HALT, return value is %.*s\n\n", (int)retstrval.length, retstrval.address);
+
+	printf("main: Initializing return value to 'snarf' for the ZHALT test\n");
+	retstrval.address = retbuf;
+	strcpy(retbuf, "snarf");
+	retstrval.length = sizeof("snarf") - 1;
+	status = ydb_ci("testcizhaltrcstr", &retstrval, useZHALT);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After ZHALT, return value is %.*s\n\n", (int)retstrval.length, retstrval.address);
+
+	printf("main: Initializing return value to 'snarf' for the ZGOTO 0 test\n");
+	retstrval.address = retbuf;
+	strcpy(retbuf, "snarf");
+	retstrval.length = sizeof("snarf") - 1;
+	status = ydb_ci("testcizhaltrcstr", &retstrval, useZGOTO0);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After ZGOTO 0, return value is %.*s\n\n", (int)retstrval.length, retstrval.address);
+
+	printf("main: Initializing return value to 'snarf' for the QUIT with no return value (but one expected) test\n");
+	retstrval.address = retbuf;
+	strcpy(retbuf, "snarf");
+	retstrval.length = sizeof("snarf") - 1;
+	status = ydb_ci("testcizhaltrcstr", &retstrval, useQUITretval);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: After QUIT with (an unexpected) return value, return value is %.*s\n\n",
+	       (int)retstrval.length, retstrval.address);
+
+	printf("main: Setting up for QUIT with (an unexpected string) return value test\n");
+	status = ydb_ci("testcizhaltnoretv",0);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: Return from QUIT with (an unexpected string) return value\n\n");
+
+	/* Now make a call with arguments to a routine that isn't expecting any - expect error */
+
+	printf("main: Initializing return value to -99 for the call with args to routine with no parms test\n");
+	retintval = -99;
+	status = ydb_ci("testcizhaltnoargs", &retintval, 42);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: Returned from testcizhaltnoargs\n\n");
+
+	/* Test complete - Close up shop */
+	status = ydb_exit();
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+
+	return 0;
+}

--- a/call_ins/inref/testcizhaltrcmain.c
+++ b/call_ins/inref/testcizhaltrcmain.c
@@ -178,6 +178,37 @@ int main(void)
 	}
 	printf("main: Return from QUIT with (an unexpected string) return value\n\n");
 
+	/* Make a call to routines we have already called (using a different entry id) but with 2 args instead
+	 * of 1 which is 1 more than expected. Should get an error - once for int and once for string retvals.
+	 */
+
+	printf("main: Setting up for call to routine with an extra (unexpected) argument\n");
+	retintval = -99;
+	status = ydb_ci("testcizhalt2manyargsint", &retintval, useHALT);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: Return from calling routine with an unexpected arg (integer retval flavor)\n\n");
+
+	printf("main: Setting up for call to routine with an extra (unexpected) argument\n");
+	retstrval.address = retbuf;
+	strcpy(retbuf, "snarf");
+	retstrval.length = sizeof("snarf") - 1;
+	status = ydb_ci("testcizhalt2manyargsint", &retstrval, useHALT);
+	if (status)
+	{
+		ydb_zstatus(errbuf, ERRBUF_SIZE);
+		printf("Return code: %d\n", status);
+		printf("%s\n", errbuf);
+		fflush(stdout);
+	}
+	printf("main: Return from calling routine with an unexpected arg (string retval flavor)\n\n");
+
+
 	/* Now make a call with arguments to a routine that isn't expecting any - expect error */
 
 	printf("main: Initializing return value to -99 for the call with args to routine with no parms test\n");

--- a/call_ins/inref/testcizhaltrcmain.c
+++ b/call_ins/inref/testcizhaltrcmain.c
@@ -14,7 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "ydbxc_types.h"
+#include "libyottadb.h"
 
 #define ERRBUF_SIZE	1024
 

--- a/call_ins/instream.csh
+++ b/call_ins/instream.csh
@@ -27,6 +27,8 @@
 # test_mprof_hidden_rtn [estess]	Verify M-Profiling functions correctly when routine is hidden behind a call-in frame
 # test_ci_z_halt	[estess]	Verify [Z]HALT in a call-in returns to caller instead of actually halting
 # test_ci_goto0		[estess]	Verify ZGOTO 0 in a call-in returns to caller after algorithmic change
+# test_ci_z_halt_rc     [estess]        Verify return values when frames exited by HALT/ZHALT/ZGOTO 0/QUIT
+#                                       work correctly.
 #
 # Options to record Load Path in executables. Similar options needed for OS390 platform
 setenv subtest_exclude_list ""
@@ -36,7 +38,7 @@ setenv subtest_list_common ""
 setenv subtest_list_non_replic "32args argcnt c_args ctomctom ctomtom gtm_args gtm_errors gtm_exit_err lngargs maxnstlvl nest_err nest_err_et"
 setenv subtest_list_non_replic "$subtest_list_non_replic nest_err_et2 nest_err_et3 nest_err_zt nest_err_zt2 nest_err_zt3 maxstrlen gtmxc_test_types"
 setenv subtest_list_non_replic "$subtest_list_non_replic xc_test_types multi_gtm_init gtm_percent gtm_cip timers empty_table stack_leak"
-setenv subtest_list_non_replic "$subtest_list_non_replic test_rtn_replace test_mprof_hidden_rtn test_ci_z_halt test_ci_zgoto0"
+setenv subtest_list_non_replic "$subtest_list_non_replic test_rtn_replace test_mprof_hidden_rtn test_ci_z_halt test_ci_zgoto0 test_ci_z_halt_rc"
 setenv subtest_list_replic "environment"
 
 if ("TRUE" == $gtm_test_unicode_support) then

--- a/call_ins/outref/outref.txt
+++ b/call_ins/outref/outref.txt
@@ -29,6 +29,7 @@ PASS from test_rtn_replace
 PASS from test_mprof_hidden_rtn
 PASS from test_ci_z_halt
 PASS from test_ci_zgoto0
+PASS from test_ci_z_halt_rc
 ##SUSPEND_OUTPUT NON_UTF8
 ##SUSPEND_OUTPUT PLATFORM_NO_4BYTE_UTF8
 PASS from unic2m2c2m

--- a/call_ins/outref/test_ci_z_halt.txt
+++ b/call_ins/outref/test_ci_z_halt.txt
@@ -2,7 +2,9 @@ testcizhalt1: Entered - Driving ^testcizhaltA
 testcizhaltA: Entered -- driving first call-in
 testcizhalt2: Entered - driving HALT now to return to call-in caller
 testcizhaltA: Back in testcizhaltA - driving second call-in
-testcizhalt3: Entered - driving ZHALT now to return to call-in caller
+testcizhalt3: Entered - driving ZHALT now to return to call-in caller (expect NOTEXTRINSIC error)
+testcizhalt3: ** Error caught ** : 150374450,testcizhalt3+4^testcizhalt3,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+Aborting testcizhalt3
 testcizhaltA: Back in testcizhaltA
 testcizhaltA: Returning
 testcizhalt1: Back in testcizhalt1 - Test complete

--- a/call_ins/outref/test_ci_z_halt.txt
+++ b/call_ins/outref/test_ci_z_halt.txt
@@ -3,7 +3,7 @@ testcizhaltA: Entered -- driving first call-in
 testcizhalt2: Entered - driving HALT now to return to call-in caller
 testcizhaltA: Back in testcizhaltA - driving second call-in
 testcizhalt3: Entered - driving ZHALT now to return to call-in caller (expect NOTEXTRINSIC error)
-testcizhalt3: ** Error caught ** : 150374450,testcizhalt3+4^testcizhalt3,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+testcizhalt3: ** Error caught ** : 150374450,testcizhalt3+4^testcizhalt3,%GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 Aborting testcizhalt3
 testcizhaltA: Back in testcizhaltA
 testcizhaltA: Returning

--- a/call_ins/outref/test_ci_z_halt_rc.txt
+++ b/call_ins/outref/test_ci_z_halt_rc.txt
@@ -1,0 +1,44 @@
+main: Initializing return value to -99 for HALT test
+main: After HALT, return value is 0
+
+main: Initializing return value to -99 for ZHALT test
+main: After ZHALT, return value is 42
+
+main: Initializing return value to -99 for ZGOTO 0 test
+main: After ZGOTO 0, return value is 0
+
+main: Initializing return value to -99 for QUIT with no return value (but one expected) test
+Return code: 150374554
+150374554,%GTM-E-QUITARGREQD, Quit from an extrinsic must have an argument
+main: After QUIT with no return value (but one expected), return value is -99
+
+main: Setting up for QUIT with (an unexpected integer) return value test
+Return code: 150374450
+150374450,testcizhaltnoretval+1^testcizhaltrc,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+main: Return from QUIT with (an unexpected integer) return value
+
+main: Initializing return value to 'snarf' for the HALT test
+main: After HALT, return value is 
+
+main: Initializing return value to 'snarf' for the ZHALT test
+main: After ZHALT, return value is 42
+
+main: Initializing return value to 'snarf' for the ZGOTO 0 test
+main: After ZGOTO 0, return value is 
+
+main: Initializing return value to 'snarf' for the QUIT with no return value (but one expected) test
+Return code: 150374554
+150374554,%GTM-E-QUITARGREQD, Quit from an extrinsic must have an argument
+main: After QUIT with (an unexpected) return value, return value is snarf
+
+main: Setting up for QUIT with (an unexpected string) return value test
+Return code: 150374450
+150374450,testcizhaltnoretval+1^testcizhaltrc,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+main: Return from QUIT with (an unexpected string) return value
+
+main: Initializing return value to -99 for the call with args to routine with no parms test
+Return code: 150374466
+150374466,%GTM-E-FMLLSTMISSING, The formal list is absent from a label called with an actual list: testcizhaltnoargs
+main: Returned from testcizhaltnoargs
+
+End of test_ci_z_halt_rc subtest

--- a/call_ins/outref/test_ci_z_halt_rc.txt
+++ b/call_ins/outref/test_ci_z_halt_rc.txt
@@ -14,7 +14,7 @@ main: After QUIT with no return value (but one expected), return value is -99
 
 main: Setting up for QUIT with (an unexpected integer) return value test
 Return code: 150374450
-150374450,testcizhaltnoretval+1^testcizhaltrc,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+150374450,testcizhaltnoretval+1^testcizhaltrc,%GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 main: Return from QUIT with (an unexpected integer) return value
 
 main: Initializing return value to 'snarf' for the HALT test
@@ -33,7 +33,7 @@ main: After QUIT with (an unexpected) return value, return value is snarf
 
 main: Setting up for QUIT with (an unexpected string) return value test
 Return code: 150374450
-150374450,testcizhaltnoretval+1^testcizhaltrc,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+150374450,testcizhaltnoretval+1^testcizhaltrc,%GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 main: Return from QUIT with (an unexpected string) return value
 
 main: Setting up for call to routine with an extra (unexpected) argument

--- a/call_ins/outref/test_ci_z_halt_rc.txt
+++ b/call_ins/outref/test_ci_z_halt_rc.txt
@@ -36,6 +36,16 @@ Return code: 150374450
 150374450,testcizhaltnoretval+1^testcizhaltrc,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
 main: Return from QUIT with (an unexpected string) return value
 
+main: Setting up for call to routine with an extra (unexpected) argument
+Return code: 150374474
+150374474,testcizhaltrcint^testcizhaltrc,%GTM-E-ACTLSTTOOLONG, More actual parameters than formal parameters: 
+main: Return from calling routine with an unexpected arg (integer retval flavor)
+
+main: Setting up for call to routine with an extra (unexpected) argument
+Return code: 150374474
+150374474,testcizhaltrcint^testcizhaltrc,%GTM-E-ACTLSTTOOLONG, More actual parameters than formal parameters: 
+main: Return from calling routine with an unexpected arg (string retval flavor)
+
 main: Initializing return value to -99 for the call with args to routine with no parms test
 Return code: 150374466
 150374466,%GTM-E-FMLLSTMISSING, The formal list is absent from a label called with an actual list: testcizhaltnoargs

--- a/call_ins/u_inref/32args.csh
+++ b/call_ins/u_inref/32args.csh
@@ -27,7 +27,6 @@ longtab
 $gt_cc_compiler $gtt_cc_shl_options $gtm_tst/$tst/inref/32args.c -I$gtm_dist
 
 $gt_ld_linker $gt_ld_option_output args $gt_ld_options_common 32args.o $gt_ld_sysrtns $ci_ldpath$gtm_dist -L$gtm_dist $tst_ld_gtmshr $gt_ld_syslibs >& link.map
-
 if( $status != 0 ) then
     cat link.map
 endif

--- a/call_ins/u_inref/ctomctom.csh
+++ b/call_ins/u_inref/ctomctom.csh
@@ -22,7 +22,6 @@ cmcm.tab
 #
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/squarec.c
 $gt_ld_shl_linker ${gt_ld_option_output}libsquare${gt_ld_shl_suffix} $gt_ld_shl_options squarec.o $gt_ld_syslibs $tst_ld_sidedeck >&! link1.map
-
 if( $status != 0 ) then
     cat link1.map
 endif
@@ -41,7 +40,6 @@ xx
 
 $gt_cc_compiler $gtt_cc_shl_options -I$gtm_tst/com -I$gtm_dist $gtm_tst/$tst/inref/ctomctom.c
 $gt_ld_linker $gt_ld_option_output cmcm $gt_ld_options_common ctomctom.o $gt_ld_sysrtns $ci_ldpath$gtm_dist -L$gtm_dist $tst_ld_gtmshr $gt_ld_syslibs >&! link2.map
-
 if( $status != 0 ) then
     cat link2.map
 endif

--- a/call_ins/u_inref/test_ci_z_halt_rc.csh
+++ b/call_ins/u_inref/test_ci_z_halt_rc.csh
@@ -22,14 +22,18 @@
 #
 
 #
-# Define the set of call-in routines we are testing
+# Define the set of call-in routines we are testing. Note we define entries for testcizhaltrcint() and
+# testcizhaltrcstr() twice - once with one arg (which we expect to work) and once with 2 args which we
+# expect to fail.
 #
 setenv GTMCI testcizhaltrc.xc
 cat >> $GTMCI << EOF
-testcizhaltrcint:  ydb_int_t    *testcizhaltrcint^testcizhaltrc(I:ydb_int_t)
-testcizhaltrcstr:  ydb_string_t *testcizhaltrcstr^testcizhaltrc(I:ydb_int_t)
-testcizhaltnoargs: ydb_int_t    *testcizhaltnoargs^testcizhaltrc(I:ydb_int_t)
-testcizhaltnoretv: void          testcizhaltnoretval^testcizhaltrc(I:ydb_int_t)
+testcizhaltrcint:         ydb_int_t    *testcizhaltrcint^testcizhaltrc(I:ydb_int_t)
+testcizhaltrcstr:         ydb_string_t *testcizhaltrcstr^testcizhaltrc(I:ydb_int_t)
+testcizhaltnoargs:        ydb_int_t    *testcizhaltnoargs^testcizhaltrc(I:ydb_int_t)
+testcizhalt2manyargsint:  ydb_int_t    *testcizhaltrcint^testcizhaltrc(I:ydb_int_t, I:ydb_int_t)
+testcizhalt2manyargsstr:  ydb_string_t *testcizhaltrcstr^testcizhaltrc(I:ydb_int_t, I:ydb_int_t)
+testcizhaltnoretv:        void          testcizhaltnoretval^testcizhaltrc(I:ydb_int_t)
 EOF
 #
 # Compile/build C main routine

--- a/call_ins/u_inref/test_ci_z_halt_rc.csh
+++ b/call_ins/u_inref/test_ci_z_halt_rc.csh
@@ -1,0 +1,47 @@
+#################################################################
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test conditions:
+#   1. C main routine does call-in to routine that expects a return value (test both int and string returns)
+#   2. Test various types of exits the routine does:
+#        a. HALT but caller expects a return value.
+#        b. ZHALT with return value which should be returned to caller.
+#        c. ZGOTO 0 but caller expects a return value.
+#        d. QUIT no return value when one is expected (expect QUITARGREQD error).
+#        e. QUIT with a return value when one is NOT expected (expect NOTEXTRINSIC error).
+#   3. Test call-in to routine supplying args when none are expected (expect FMLLSTMISSING error).
+#
+
+#
+# Define the set of call-in routines we are testing
+#
+setenv GTMCI testcizhaltrc.xc
+cat >> $GTMCI << EOF
+testcizhaltrcint:  ydb_int_t    *testcizhaltrcint^testcizhaltrc(I:ydb_int_t)
+testcizhaltrcstr:  ydb_string_t *testcizhaltrcstr^testcizhaltrc(I:ydb_int_t)
+testcizhaltnoargs: ydb_int_t    *testcizhaltnoargs^testcizhaltrc(I:ydb_int_t)
+testcizhaltnoretv: void          testcizhaltnoretval^testcizhaltrc(I:ydb_int_t)
+EOF
+#
+# Compile/build C main routine
+#
+$gt_cc_compiler $gtt_cc_shl_options $gtm_tst/$tst/inref/testcizhaltrcmain.c -I$gtm_dist
+$gt_ld_linker $gt_ld_option_output testcizhaltrcmain $gt_ld_options_common testcizhaltrcmain.o $gt_ld_sysrtns $ci_ldpath$gtm_dist -L$gtm_dist $tst_ld_gtmshr $gt_ld_syslibs >& link.map
+if( $status != 0 ) then
+    cat link.map
+endif
+#
+# Drive main test
+#
+testcizhaltrcmain
+#
+echo "End of test_ci_z_halt_rc subtest"

--- a/errors/outref/err_messages.txt
+++ b/errors/outref/err_messages.txt
@@ -181,7 +181,7 @@ M16 ; Argumented QUIT not allowed
  Set $ECode=",Z16-Error didn't happen,"
  Quit
  ;
-150374450,exfun+1^erransi,%GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+150374450,exfun+1^erransi,%GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 ,M16,Z150374450,
 
 150379506,M16+2^erransi,%GTM-E-SETECODE, Non-empty value assigned to $ECODE (user-defined error trap)

--- a/suppl_inst_B/outref/supplementary_err.txt
+++ b/suppl_inst_B/outref/supplementary_err.txt
@@ -33,7 +33,7 @@ Error UPDSYNCINSTFILE seen in ##FILTERED##RCVR_##TIMESTAMP##.log as expected:
 ==Executing MULTISITE_REPLIC 'RUN INST4 ##TEST_COM_PATH##/check_error_exist.csh ##FILTERED##RCVR_##TIMESTAMP##.log REPL2OLD'==
 ----------
 Error REPL2OLD seen in ##FILTERED##RCVR_##TIMESTAMP##.log as expected:
-%GTM-E-REPL2OLD, Instance INSTANCE2 uses a GT.M version that does not support connection with the current version on instance INSTANCE4
+%GTM-E-REPL2OLD, Instance INSTANCE2 uses a GT.M/YottaDB version that does not support connection with the current version on instance INSTANCE4
 ----------
 # The receiver would have exited with the above error. Manually shutdown the update process and passive server
 ==Executing MULTISITE_REPLIC 'RUN INST4 set msr_dont_chk_stat ; $MUPIP replic -receiver -shutdown -timeout=0 >&! updateproc_shut_IST2INST4.out'==
@@ -46,7 +46,7 @@ Error REPL2OLD seen in ##FILTERED##RCVR_##TIMESTAMP##.log as expected:
 ==Executing MULTISITE_REPLIC 'RUN INST4 ##TEST_COM_PATH##/check_error_exist.csh ##FILTERED##SRC_##TIMESTAMP##.log REPL2OLD'==
 ----------
 Error REPL2OLD seen in ##FILTERED##SRC_##TIMESTAMP##.log as expected:
-%GTM-E-REPL2OLD, Instance INSTANCE2 uses a GT.M version that does not support connection with the current version on instance INSTANCE4
+%GTM-E-REPL2OLD, Instance INSTANCE2 uses a GT.M/YottaDB version that does not support connection with the current version on instance INSTANCE4
 ----------
 ==Executing MULTISITE_REPLIC 'REFRESHLINK INST4 INST2'==
 ==Executing MULTISITE_REPLIC 'STOPRCV INST4 INST2'==

--- a/v55000/outref/GTM6813.txt
+++ b/v55000/outref/GTM6813.txt
@@ -907,18 +907,18 @@ X is FAIL: %GTM-E-UNDEF, Undefined local variable: x
 ###################################################################
 Testing gtm_zquit_anyway environment variable and quit argument evaluation...
 
-HFAIL: %GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+HFAIL: %GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 EFAIL: %GTM-E-UNDEF, Undefined local variable: arg
 OFAIL: %GTM-E-UNDEF, Undefined local variable: x
-FAIL: %GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
-WFAIL: %GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+FAIL: %GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
+WFAIL: %GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 ORFAIL: %GTM-E-UNDEF, Undefined local variable: x
 FAIL: %GTM-E-QUITARGREQD, Quit from an extrinsic must have an argument
 
-HFAIL: %GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+HFAIL: %GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 ELLFAIL: %GTM-E-QUITARGREQD, Quit from an extrinsic must have an argument
-O FAIL: %GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
-WFAIL: %GTM-E-NOTEXTRINSIC, Quit does not return to an extrinsic function: argument not allowed
+O FAIL: %GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
+WFAIL: %GTM-E-NOTEXTRINSIC, QUIT/ZHALT does not return to an extrinsic function: argument not allowed
 ORLFAIL: %GTM-E-QUITARGREQD, Quit from an extrinsic must have an argument
 
 HEFAIL: %GTM-E-UNDEF, Undefined local variable: arg


### PR DESCRIPTION
General change for all new tests - change gtm_* types and routine names to ydb_*.

call_ins/inref/drivecirtn.c
  - gtm_* -> ydb_*

call_ins/inref/testcizhaltrc.m
  - Houses call-in entryrefs for new test_ci_z_halt_rc subtest

call_ins/inref/testcizhaltrcmain.c
  - Main C driver routine for new test_ci_z_halt_rc subtest

call_ins/instream.csh
  - Add test_ci_z_halt_rc subtest

call_ins/outref/outref.txt
  - Add new test_ci_z_halt_rc subtest completion message to reference file

call_ins/outref/test_ci_z_halt_rc.txt
  - Reference file for new test_ci_z_halt_rc subtes

call_ins/u_inref/32args.csh
  - Remove blank line

call_ins/u_inref/ctomctom.csh
  - Remove blank lines

call_ins/u_inref/test_ci_z_halt_rc.csh
  - Driver script for new test_ci_z_halt_rc subtest