### PR TITLE
[NARS1] [estess] Fix v62001/gtm8206 test failure due to code now runn…

### DIFF
--- a/v62001/outref/gtm8206.txt
+++ b/v62001/outref/gtm8206.txt
@@ -1,3 +1,2 @@
-# Running expect (output: expect.out)
-1
-1
+# Running expect (output: expect.out) : Expecting a GTM-I-CTRLC message
+%GTM-I-CTRLC, CTRL_C encountered

--- a/v62001/u_inref/gtm8206.csh
+++ b/v62001/u_inref/gtm8206.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2014 Fidelity Information Services, Inc	#
+# Copyright 2014 Fidelity Information Services, Inc		#
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -11,8 +14,6 @@
 #################################################################
 
 setenv TERM vt320
-echo "# Running expect (output: expect.out)"
+echo "# Running expect (output: expect.out) : Expecting a GTM-I-CTRLC message"
 expect $gtm_tst/$tst/u_inref/gtm8206.exp > expect.out
-$grep -c CTRL_C expect.out
-$grep -c "PASS" expect.out
-endif
+$grep CTRL_C expect.out

--- a/v62001/u_inref/gtm8206.exp
+++ b/v62001/u_inref/gtm8206.exp
@@ -3,6 +3,9 @@
 # Copyright (c) 2014-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -22,22 +25,17 @@ send -- "\r"
 expect "GTM>"
 send -- "set \$etrap=\"set x=\$zjobexam(),\$ecode=\"\"\"\"\"\r"
 expect "GTM>"
-send -- "for i=1:1:2000000 set a(i)=i\r"
+send -- "for i=1:1:10000 set a(i)=i\r"
 expect "GTM>"
 # the next thing seems nonsensical but it keeps at least one solaris box from sailing past the merge
 send -- "write \$zdate(\$horolog)\r"
 expect "GTM>"
-send -- "write \$char(77,69,82,71,69) xecute \"merge b=a\"\r"
+send -- "write \$char(77,69,82,71,69) xecute \"for i=1:1 merge b(i)=a\"\r"
 sleep 2
 # send ctrl-c
 expect "MERGE"
 send -- "\003"
 # since cenable is the default we should see the CTRL_C message
 expect "CTRL_C encountered"
-send -- "xecute \"write \$data(b(1)),\$data(b(2000000)),b(1)\"\r"
-expect {
-        default {puts "TEST-E-FAIL, ...\r"}
-    "101" {puts "TEST-I-PASS, ...\r"}
-}
 send -- halt\r
 expect "CTRLC>"


### PR DESCRIPTION
…ing lot faster than before

The test did the below (in an expect script).

	for i=1:1:2000000 set a(i)=i
	merge b=a

And sends a Ctrl-C 2 seconds after the merge command has started. That usually takes 8 seconds to run even on a fast server and so the Ctrl-C always happens and b(2000000) is never set when the test checks it later. But with the latest stpg_sort() performance enhancements (see https://github.com/YottaDB/YottaDB/issues/85), the merge finished in 0.7 seconds and so the Ctrl-C was a no-op. And disturbed the timing that the test was expecting resulting in a failure.

The test is now fixed by changing the "merge b=a" to a "for i=1:1  merge b(i)=a" so we are guaranteed it is an infinite loop however fast a machine is. And after 2 seconds the test will interrupt this process and check if a GTM-I-CTRLC message shows up (like it used to). But the check that b(2000000) is indeed undefined is now removed. That is an indirect verification of the fact that the for loop did not run to completion due to the Ctrl-C and not necessary in my opinion since we are about to issue a "halt" soon after and if the loop indeed did not get interrupted, the halt would not get control and the test would not finish.