### PR TITLE
[NARS1] [estess] Add r120/patnotfound subtest to test PATNOTFOUND err…

### DIFF
--- a/r120/inref/patnotfound1.m
+++ b/r120/inref/patnotfound1.m
@@ -1,0 +1,12 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.	     	  	     			;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+	if 1?1B

--- a/r120/inref/patnotfound2.m
+++ b/r120/inref/patnotfound2.m
@@ -1,0 +1,12 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.	     	  	     			;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+	xecute "if ""a""?1B"

--- a/r120/inref/patnotfound3.m
+++ b/r120/inref/patnotfound3.m
@@ -1,0 +1,12 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.	     	  	     			;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+	if 1?1B,!

--- a/r120/inref/patnotfound4.m
+++ b/r120/inref/patnotfound4.m
@@ -1,0 +1,20 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.	     	  	     			;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+main	;
+	do good
+	quit
+bad	;
+	if 1?1B
+	quit
+good	;
+	write "hello",!
+	quit

--- a/r120/instream.csh
+++ b/r120/instream.csh
@@ -17,13 +17,14 @@
 # zindcacheoverflow [ashok]	Test fix to indirect code cache stats 4-byte overflow error
 # largelvarray       [nars]	Test local array performance does not deteriorate exponentially with large # of nodes
 # gctest             [nars]	Test stringpool garbage collection performance with lots of strings in the pool
+# patnotfound        [nars]	Test runtime behavior after PATNOTFOUND compile-time error
 #-------------------------------------------------------------------------------------
 
 echo "r120 test starts..."
 
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
-setenv subtest_list_non_replic "zindcacheoverflow largelvarray gctest"
+setenv subtest_list_non_replic "zindcacheoverflow largelvarray gctest patnotfound"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/r120/outref/outref.txt
+++ b/r120/outref/outref.txt
@@ -7,5 +7,6 @@ PASS from largelvarray
 ##SUSPEND_OUTPUT DBG
 PASS from gctest
 ##ALLOW_OUTPUT DBG
+PASS from patnotfound
 ##ALLOW_OUTPUT REPLIC
 r120 test DONE.

--- a/r120/outref/patnotfound.txt
+++ b/r120/outref/patnotfound.txt
@@ -1,10 +1,10 @@
  --> Running test with patnotfound1.m <---
 		if 1?1B
 		       ^-----
-		At column 9, line 1, source module ##IN_TEST_PATH##/inref/patnotfound1.m
+		At column 9, line 12, source module ##IN_TEST_PATH##/inref/patnotfound1.m
 %GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
-%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code
-		At M source location +1^patnotfound1
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code 
+		At M source location +12^patnotfound1
 
 GTM>
 
@@ -16,17 +16,17 @@ GTM>
  --> Running test with patnotfound3.m <---
 		if 1?1B,!
 		       ^-----
-		At column 9, line 1, source module ##IN_TEST_PATH##/inref/patnotfound3.m
+		At column 9, line 12, source module ##IN_TEST_PATH##/inref/patnotfound3.m
 %GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
-%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code
-		At M source location +1^patnotfound3
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code 
+		At M source location +12^patnotfound3
 
 GTM>
 
  --> Running test with patnotfound4.m <---
 		if 1?1B
 		       ^-----
-		At column 9, line 5, source module ##IN_TEST_PATH##/inref/patnotfound4.m
+		At column 9, line 16, source module ##IN_TEST_PATH##/inref/patnotfound4.m
 %GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
 hello
 

--- a/r120/outref/patnotfound.txt
+++ b/r120/outref/patnotfound.txt
@@ -1,0 +1,32 @@
+ --> Running test with patnotfound1.m <---
+		if 1?1B
+		       ^-----
+		At column 9, line 1, source module ##IN_TEST_PATH##/inref/patnotfound1.m
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code
+		At M source location +1^patnotfound1
+
+GTM>
+
+ --> Running test with patnotfound2.m <---
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
+%GTM-E-ZLINKFILE, Error while zlinking "##IN_TEST_PATH##/inref/patnotfound2.m"
+%GTM-E-ZLNOOBJECT, No object module was produced
+
+ --> Running test with patnotfound3.m <---
+		if 1?1B,!
+		       ^-----
+		At column 9, line 1, source module ##IN_TEST_PATH##/inref/patnotfound3.m
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code
+		At M source location +1^patnotfound3
+
+GTM>
+
+ --> Running test with patnotfound4.m <---
+		if 1?1B
+		       ^-----
+		At column 9, line 5, source module ##IN_TEST_PATH##/inref/patnotfound4.m
+%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
+hello
+

--- a/r120/u_inref/patnotfound.csh
+++ b/r120/u_inref/patnotfound.csh
@@ -1,0 +1,23 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test runtime behavior after PATNOTFOUND compile-time error
+#
+
+cp $gtm_tst/$tst/inref/patnotfound*.m .
+
+foreach file (patnotfound*.m)
+	echo " --> Running test with $file <---"
+	$gtm_dist/mumps -run $file:r
+	echo ""
+end


### PR DESCRIPTION
…or handling (see YottaDB/YottaDB#90)

See YottaDB/YottaDB#90 for a description of the issue and corresponding test cases. Those test cases are folded into this automated test.
There are 4 M programs. And each of them are included because they show different failure symptoms with R110 pro and dbg. Below is the output of those test programs with the older code. All of them run correctly with the code fix.

R110 pro build output
---------------------
```
 --> Running test with patnotfound1.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code

 --> Running test with patnotfound2.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-E-ZLINKFILE, Error while zlinking "/usr/library/gtm_test/T998/r120/inref/patnotfound2.m"
%GTM-E-ZLNOOBJECT, No object module was produced

 --> Running test with patnotfound3.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-F-KILLBYSIGSINFO1, GT.M process 14353 has been killed by a signal 11 at address 0x00007F90F6C0E8A3 (vaddr 0x0000000000000000)
%GTM-F-SIGMAPERR, Signal was caused by an address not mapped to an object

 --> Running test with patnotfound4.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-F-KILLBYSIGSINFO1, GT.M process 14355 has been killed by a signal 11 at address 0x00007F7CDB8D700F (vaddr 0x00007F7CDB8D700F)
%GTM-F-SIGMAPERR, Signal was caused by an address not mapped to an object
```

R110 dbg build output
---------------------
```
 --> Running test with patnotfound1.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-F-GTMASSERT, GT.M V6.3-002 Linux x86_64 - Assert failed /Distrib/GT.M/V63002/sr_port/chktchain.c line 28

 --> Running test with patnotfound2.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-F-ASSERT, Assert failed in /Distrib/GT.M/V63002/sr_port/zlcompile.c line 81 for expression ((FALSE == run_time) && (TRUE == TREF(compile_time)))

 --> Running test with patnotfound3.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-F-ASSERT, Assert failed in /Distrib/GT.M/V63002/sr_port/code_gen.c line 51 for expression (0 == pending_errtriplecode)

 --> Running test with patnotfound4.m <---
%GTM-E-PATNOTFOUND, Current pattern table has no characters with pattern code B
%GTM-F-GTMASSERT, GT.M V6.3-002 Linux x86_64 - Assert failed /Distrib/GT.M/V63002/sr_port/chktchain.c line 28
```