### PR TITLE
Get java test to actually run (and pass) in YottaDB setup

### DIFF
--- a/com/set_java_paths.csh
+++ b/com/set_java_paths.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2013-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -16,7 +19,17 @@
 # (by sourcing this script) to set up environment for Java call-ins and call-outs.
 
 setenv JAVA_HOME `awk '$0 ~ /^#/ {next;} $1 ~ /^'$HOST:r:r:r'/ {print $10}' $gtm_test_serverconf_file`	# BYPASSOK
-if (("NA" == $JAVA_HOME) || ("" == $JAVA_HOME)) then
+if ("NA" == $JAVA_HOME) then
+	# Check if /usr/lib/jvm/*/jre directory can be found. If so use that.
+	set nonomatch = 1 ; set jrelist = /usr/lib/jvm/*/jre; unset nonomatch
+	if ("$jrelist" != '/usr/lib/jvm/*/jre') then
+		# There might be multiple versions. In that case, choose the last one (hopefully the latest in terms of version)
+		setenv JAVA_HOME $jrelist[$#jrelist]:h
+	else
+		setenv JAVA_HOME ""
+	endif
+endif
+if ("" == $JAVA_HOME) then
 	echo "Java is not available on this platform, or the installation path is missing in $gtm_test_serverconf_file"
 	exit 1
 endif

--- a/com/set_java_supported.csh
+++ b/com/set_java_supported.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2013 Fidelity Information Services, Inc	#
+# Copyright 2013 Fidelity Information Services, Inc		#
+#								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -11,7 +14,7 @@
 #################################################################
 
 # Get relevant paths initialized for Java.
-source $gtm_tst/com/set_java_paths.csh >&! /dev/null
+source $gtm_tst/com/set_java_paths.csh
 
 # Set gtm_test_java_supported if applicable.
 if (! $status) then

--- a/com/submit.csh
+++ b/com/submit.csh
@@ -19,7 +19,6 @@
 set format="%Y.%m.%d.%H.%M.%S.%Z"
 set alltests_begin = `date +"$format"`
 source $gtm_tst/com/set_gtm_machtype.csh
-source $gtm_tst/com/set_java_supported.csh
 
 setenv test_pid_file /tmp/__${USER}_test_suite_$$.pid
 echo $tst_dir/$gtm_tst_out >>! $test_pid_file
@@ -30,6 +29,8 @@ setenv gtm_test_local_debugdir $tst_dir/$gtm_tst_out/debugfiles/
 if (! -e $gtm_test_local_debugdir) mkdir -p $gtm_test_local_debugdir
 touch $gtm_test_local_debugdir/excluded_subtests.list
 touch $gtm_test_local_debugdir/test_subtest.info
+
+source $gtm_tst/com/set_java_supported.csh >>! $gtm_test_local_debugdir/set_java_supported.log
 
 # Don't log timing info if only a subset of subtests will run or if dryrun of test is done
 if (($?gtm_test_st_list)||($?gtm_test_dryrun)) then

--- a/java/inref/com.test.ji.TestCase.java
+++ b/java/inref/com.test.ji.TestCase.java
@@ -1,6 +1,9 @@
 /****************************************************************
 *								*
-*	Copyright 2013 Fidelity Information Services, Inc	*
+* Copyright 2013 Fidelity Information Services, Inc		*
+*								*
+* Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+* All rights reserved.						*
 *								*
 *	This source code contains the intellectual property	*
 *	of its copyright holder(s), and is made available	*
@@ -357,10 +360,14 @@ public abstract class TestCase {
 	/* Write the call-in or call-out table to a file. */
 	private static void writeTable(String tableFile, String tableEntries, boolean callin) throws IOException {
 		StringBuilder mBuilder = new StringBuilder();
+		String	gtmDist;
 		if (!callin)
-			mBuilder.append("/usr/library/com/gtmji/libgtmm2j.so\n");
+		{
+			gtmDist = System.getenv("gtm_dist");
+			mBuilder.append(gtmDist);
+			mBuilder.append("/plugin/libgtmm2j.so\n");
+		}
 		mBuilder.append(tableEntries);
-
 		BufferedWriter writer = getWriter(tableFile);
 		writer.write(mBuilder.toString());
 		writer.close();

--- a/java/instream.csh
+++ b/java/instream.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2013-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -19,87 +22,75 @@
 
 echo "java test starts..."
 
-set hostn = $HOST:r:r:r
+# Run with unicode.
+setenv gtm_test_unicode "TRUE"
+$switch_chset "UTF-8" >&! switch_utf8.log
 
-if ( ("TRUE" == "$gtm_test_unicode_support") && ("$gtm_test_java_support") && ("kishoreh" != "$hostn") ) then
-	# Java is supported.
-	set no_java = 0
+# List the subtests separated by spaces under the appropriate environment variable name.
+setenv subtest_list  "callins callouts"
 
-	# Run with unicode.
-	setenv gtm_test_unicode "TRUE"
-	$switch_chset "UTF-8" >&! switch_utf8.log
+# Use $subtest_exclude_list to remove subtests that are to be disabled on a particular host or OS.
+setenv subtest_exclude_list	""
 
-	# List the subtests separated by spaces under the appropriate environment variable name.
-	setenv subtest_list  "callins callouts"
+setenv gtmji_dir $gtm_dist/plugin
+if ($?alt_gtmji_dir) then
+	setenv gtmji_dir $alt_gtmji_dir
+endif
 
-	# Use $subtest_exclude_list to remove subtests that are to be disabled on a particular host or OS.
-	setenv subtest_exclude_list	""
+# Set environment variables required to run Java call-ins and call-outs.
+if ("AIX" == $HOSTOS) then
+	if (! ($?LIBPATH) ) setenv LIBPATH ""
+	if (! ($?LDR_PRELOAD64) ) setenv LDR_PRELOAD64 ""
+	setenv LIBPATH ${LIBPATH}:${JAVA_SO_HOME}:${JVM_SO_HOME}:${gtmji_dir}
+	setenv lib_preload_init ${LDR_PRELOAD64}
+	setenv lib_preload ${LDR_PRELOAD64}:${JAVA_SO_HOME}/libjsig.so
 else
-	set no_java = 1
-	setenv subtest_list ""
+	if (! ($?LD_LIBRARY_PATH) ) setenv LD_LIBRARY_PATH ""
+	if (! ($?LD_PRELOAD) ) setenv LD_PRELOAD ""
+	setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${JAVA_SO_HOME}:${JVM_SO_HOME}:${gtmji_dir}
+	setenv lib_preload_init ${LD_PRELOAD}
+	setenv lib_preload ${LD_PRELOAD}:${JAVA_SO_HOME}/libjsig.so
 endif
 
-if (! $no_java) then
-	setenv gtmji_dir $gtm_com/gtmji
-	if ($?alt_gtmji_dir) then
-		setenv gtmji_dir $alt_gtmji_dir
-	endif
+# Have a bigger stack limit (some platforms seem to need it).
+setenv jvm_flags "-Xss4M"
+setenv bin_subdir ""
 
-	# Set environment variables required to run Java call-ins and call-outs.
-	if ("AIX" == $HOSTOS) then
-		if (! ($?LIBPATH) ) setenv LIBPATH ""
-		if (! ($?LDR_PRELOAD64) ) setenv LDR_PRELOAD64 ""
-		setenv LIBPATH ${LIBPATH}:${JAVA_SO_HOME}:${JVM_SO_HOME}:${gtmji_dir}
-		setenv lib_preload_init ${LDR_PRELOAD64}
-		setenv lib_preload ${LDR_PRELOAD64}:${JAVA_SO_HOME}/libjsig.so
-	else
-		if (! ($?LD_LIBRARY_PATH) ) setenv LD_LIBRARY_PATH ""
-		if (! ($?LD_PRELOAD) ) setenv LD_PRELOAD ""
-		setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${JAVA_SO_HOME}:${JVM_SO_HOME}:${gtmji_dir}
-		setenv lib_preload_init ${LD_PRELOAD}
-		setenv lib_preload ${LD_PRELOAD}:${JAVA_SO_HOME}/libjsig.so
-	endif
-
-	# Have a bigger stack limit (some platforms seem to need it).
-	setenv jvm_flags "-Xss4M"
-	setenv bin_subdir ""
-
-	# Set JVM flags for 64-bit execution mode.
-	if ("SunOS" == $HOSTOS) then
-		setenv jvm_flags "$jvm_flags -d64"
-		setenv bin_subdir "sparcv9/"
-	else if ("AIX" == $HOSTOS) then
-		setenv jvm_flags "$jvm_flags -Xmso4M"
-	else if ("Linux" == $HOSTOS) then
-		# JVMs do not support huge pages, so disable (just unsetting the GT.M
-		# test environment variable for huge pages does not work).
-		setenv jvm_flags "$jvm_flags -XX:-UseLargePages"
-		setenv GTMXC_jvm_options "-XX:-UseLargePages"
-	endif
-
-	# Define envvar for SIGUSR1 value on all platforms (for certain tests).
-	if (("OSF1" == $HOSTOS) || ("AIX" == $HOSTOS)) then
-		setenv sigusrval 30
-	else if (("SunOS" == $HOSTOS) || ("HP-UX" == $HOSTOS) || ("OS/390" == $HOSTOS)) then
-		setenv sigusrval 16
-	else if ("Linux" == $HOSTOS) then
-		setenv sigusrval 10
-	endif
-
-	# Save Java environment settings in a special file.
-	echo "#\!/usr/local/bin/tcsh -f"							>> $tst_general_dir/set_java_env.csh
-	echo "# Use this file to set Java environment used by 'java' test on the current box."	>> $tst_general_dir/set_java_env.csh
-	echo "cp -r * $tst_general_dir/tmp"							>> $tst_general_dir/set_java_env.csh
-	echo "cd $tst_general_dir/tmp"								>> $tst_general_dir/set_java_env.csh
-	echo "setenv JAVA_HOME $JAVA_HOME"							>> $tst_general_dir/set_java_env.csh
-	echo "setenv gtmji_dir $gtmji_dir"							>> $tst_general_dir/set_java_env.csh
-	echo "setenv LD_LIBRARY_PATH $LD_LIBRARY_PATH"						>> $tst_general_dir/set_java_env.csh
-	echo "setenv LIBPATH $LIBPATH"								>> $tst_general_dir/set_java_env.csh
-	echo "setenv lib_preload_init $lib_preload_init"					>> $tst_general_dir/set_java_env.csh
-	echo "setenv lib_preload $lib_preload"							>> $tst_general_dir/set_java_env.csh
-	echo 'setenv jvm_flags "'$jvm_flags'"'							>> $tst_general_dir/set_java_env.csh
-	echo "setenv bin_subdir $bin_subdir"							>> $tst_general_dir/set_java_env.csh
+# Set JVM flags for 64-bit execution mode.
+if ("SunOS" == $HOSTOS) then
+	setenv jvm_flags "$jvm_flags -d64"
+	setenv bin_subdir "sparcv9/"
+else if ("AIX" == $HOSTOS) then
+	setenv jvm_flags "$jvm_flags -Xmso4M"
+else if ("Linux" == $HOSTOS) then
+	# JVMs do not support huge pages, so disable (just unsetting the GT.M
+	# test environment variable for huge pages does not work).
+	setenv jvm_flags "$jvm_flags -XX:-UseLargePages"
+	setenv GTMXC_jvm_options "-XX:-UseLargePages"
 endif
+
+# Define envvar for SIGUSR1 value on all platforms (for certain tests).
+if (("OSF1" == $HOSTOS) || ("AIX" == $HOSTOS)) then
+	setenv sigusrval 30
+else if (("SunOS" == $HOSTOS) || ("HP-UX" == $HOSTOS) || ("OS/390" == $HOSTOS)) then
+	setenv sigusrval 16
+else if ("Linux" == $HOSTOS) then
+	setenv sigusrval 10
+endif
+
+# Save Java environment settings in a special file.
+echo "#\!/usr/local/bin/tcsh -f"							>> $tst_general_dir/set_java_env.csh
+echo "# Use this file to set Java environment used by 'java' test on the current box."	>> $tst_general_dir/set_java_env.csh
+echo "cp -r * $tst_general_dir/tmp"							>> $tst_general_dir/set_java_env.csh
+echo "cd $tst_general_dir/tmp"								>> $tst_general_dir/set_java_env.csh
+echo "setenv JAVA_HOME $JAVA_HOME"							>> $tst_general_dir/set_java_env.csh
+echo "setenv gtmji_dir $gtmji_dir"							>> $tst_general_dir/set_java_env.csh
+echo "setenv LD_LIBRARY_PATH $LD_LIBRARY_PATH"						>> $tst_general_dir/set_java_env.csh
+echo "setenv LIBPATH $LIBPATH"								>> $tst_general_dir/set_java_env.csh
+echo "setenv lib_preload_init $lib_preload_init"					>> $tst_general_dir/set_java_env.csh
+echo "setenv lib_preload $lib_preload"							>> $tst_general_dir/set_java_env.csh
+echo 'setenv jvm_flags "'$jvm_flags'"'							>> $tst_general_dir/set_java_env.csh
+echo "setenv bin_subdir $bin_subdir"							>> $tst_general_dir/set_java_env.csh
 
 # Submit the list of subtests
 $gtm_tst/com/submit_subtest.csh


### PR DESCRIPTION
* com/set_java_paths.csh : If $gtm_test_serverconf_file does not define an explicit location for the java installation,
try to find it out on-the-fly. This will avoid having to hardcode the java path for each new system added to the
testing cluster.

* com/set_java_supported.csh : Do not redirect output of set_java_paths.csh call to /dev/null as it might be useful
in debugging.

* com/submit.csh : Now that set_java_paths.csh call in set_java_supported.csh does not redirect its output to
/dev/null, the parent script invocation (set_java_suported.csh) could produce a non-zero output so redirect that
to a file in $gtm_test_local_debugdir

* java/inref/com.test.ji.TestCase.java : gtmji is now installed in $gtm_dist/plugin (and not
/usr/library/com). i.e. the plugin is version specific.

* java/instream.csh : setenv gtmji_dir to $gtm_dist/plugin as that is the new gtmji install path; Run the test
always, whether or not java is supported on this platform (previously the test would pass indicating the java test
actually ran even though it did not run any subtest)