### PR TITLE
Fix java/callins subtest failure due to change in HALT behavior insid…

### DIFF
--- a/java/inref/com.test.ji.TestCI.java
+++ b/java/inref/com.test.ji.TestCI.java
@@ -1,14 +1,17 @@
 /****************************************************************
-*								*
+ *								*
  * Copyright (c) 2013-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
-*								*
-*	This source code contains the intellectual property	*
-*	of its copyright holder(s), and is made available	*
-*	under a license.  If you do not know the terms of	*
-*	the license, please stop and do not read further.	*
-*								*
-****************************************************************/
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
 package com.test.ji;
 
 import java.io.UnsupportedEncodingException;
@@ -857,12 +860,21 @@ public class TestCI {
 					builder.append(javaHeader);
 					builder.append("\t\ttry {\n");
 					builder.append("\t\t\tGTMCI.doVoidJob(\"" + name + "\");\n");
-					builder.append("\t\t\tSystem.out.println(\"TEST-F-FAIL, This should not get printed!\");\n");
+					/* Starting r1.10, due to issue #32, a HALT inside a call-in returns to the caller
+					 * instead of exiting and therefore we should expect the next line to be displayed
+					 * even though the previous line did a call-in that in turn did a HALT.
+					 */
+					builder.append("\t\t\tSystem.out.println(\"This should get displayed even though previous call-in did a HALT!\");\n");
 					builder.append("\t\t} catch (Exception e) {\n");
 					builder.append("\t\t\tSystem.out.println(e.getMessage());\n");
 					builder.append("\t\t}\n");
 					builder.append("\t}\n");
 					return builder.toString();
+				}
+
+				@Override
+				public String getJavaResponse() {
+					return "This should get displayed even though previous call-in did a HALT!\n";
 				}
 			}
 		};

--- a/java/u_inref/callins.csh
+++ b/java/u_inref/callins.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2013-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -13,9 +16,6 @@
 
 # This test verifies that call-ins from Java into GT.M work as expected. The test uses Java code to generate the actual
 # test M and Java routines, call-in tables, and expected output files on-the-fly.
-
-# In case there is no Java on the box, exit right away.
-if ("NA" == $JAVA_HOME) exit
 
 # Get the generic Java settings file.
 cp $tst_general_dir/set_java_env.csh .

--- a/java/u_inref/callouts.csh
+++ b/java/u_inref/callouts.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2013-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -13,9 +16,6 @@
 
 # This test verifies that call-outs to Java from GT.M work as expected. The test uses Java code to generate the actual
 # test M and Java routines, call-out tables, and expected output files on-the-fly.
-
-# In case there is no Java on the box, exit right away.
-if ("NA" == $JAVA_HOME) exit
 
 # Get the generic Java settings file.
 cp $tst_general_dir/set_java_env.csh .


### PR DESCRIPTION
…e a call-in (in r1.10, see YottaDB/YottaDB#32)

As part of r1.10, a code change was made so HALT inside a call-in returns back to the C or Java caller instead of exiting the process. This caused Test 9 to behave differently. The expected output as well as the actual output (both of which are generated) are now modified to reflect new code behavior.