### PR TITLE
[#33] [NARS1] [estess] Test changes due to utilities now using libgtmshr.so

### DIFF
--- a/errors/u_inref/test_fao.csh
+++ b/errors/u_inref/test_fao.csh
@@ -25,8 +25,7 @@ if ($status) then
 	exit 1
 endif
 # Don't change the following gt_cc_compiler to gt_ld_linker -- hppa needs gt_cc_compiler
-$gt_cc_compiler $gt_ld_options_common -o runfaotest test_fao.o -L$gtm_obj -lmumps \
-	-lgnpclient -lcmisockettcp $gt_ld_extra_libs $gt_ld_syslibs >& linker.out
+$gt_cc_compiler $gt_ld_options_common -o runfaotest test_fao.o -L$gtm_obj -lmumps $gt_ld_extra_libs $gt_ld_syslibs >& linker.out
 if ($status) then
 	echo "TEST-E-LINK Error from Linker ($gt_cc_compiler).  See file linker.out for details"
 	exit 1

--- a/v53003/outref/errors_gtm_dist.txt
+++ b/v53003/outref/errors_gtm_dist.txt
@@ -1,9 +1,11 @@
 ##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_DBCERTIFY.log
-##TEST_AWK%GTM-E-LOGTOOLONG, Environment variable .gtm_dist is too long. Maximum length allowed is [0-9][0-9]* bytes.
+##TEST_AWK%GTM-E-DISTPATHMAX, .gtm_dist path is greater than maximum .[0-9][0-9]*.
 ##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_DSE.log
 ##TEST_AWK%GTM-E-DISTPATHMAX, .gtm_dist path is greater than maximum .[0-9][0-9]*.
-##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_GTCM_GNP_SERVER2.log
-%GTM-F-FORCEDHALT, Image HALTed by MUPIP STOP
+##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_GTCM_GNP_SERVER.log
+##TEST_AWK%GTM-E-DISTPATHMAX, .gtm_dist path is greater than maximum .[0-9][0-9]*.
+##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_GTCM_SERVER.log
+##TEST_AWK%GTM-E-DISTPATHMAX, .gtm_dist path is greater than maximum .[0-9][0-9]*.
 ##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_GTM.log
 ##TEST_AWK%GTM-E-DISTPATHMAX, .gtm_dist path is greater than maximum .[0-9][0-9]*.
 ##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_LKE.log

--- a/v62001/u_inref/hash.csh
+++ b/v62001/u_inref/hash.csh
@@ -22,7 +22,7 @@ if ($tst_image == "dbg") set opts=($gt_cc_option_debug $gt_cc_option_DDEBUG)
 echo "Compiling Hash Test"
 $gt_cc_compiler -o ./hash.o $gtt_cc_shl_options $gt_cc_option_I $opts $gtm_tst/$tst/inref/hash.c
 echo "Linking Hash Test"
-$gt_ld_linker $gt_ld_option_output ./hash $gt_ld_options_common ./hash.o -L$gtm_dist/obj -lmumps -lstub $gt_ld_sysrtns $gt_ld_syslibs >& makeexe.out
+$gt_ld_linker $gt_ld_option_output ./hash $gt_ld_options_common ./hash.o -L$gtm_dist/obj -lmumps $gt_ld_sysrtns $gt_ld_syslibs >& makeexe.out
 
 echo "Starting Hash Test"
 ./hash

--- a/v62002/u_inref/zwritesvn.csh
+++ b/v62002/u_inref/zwritesvn.csh
@@ -20,7 +20,7 @@ if ($tst_image == "dbg") set opts=($gt_cc_option_debug $gt_cc_option_DDEBUG)
 
 # Compile and link svndump
 $gt_cc_compiler $gtt_cc_shl_options $opts $gtm_tst/$tst/inref/svndump.c -o svndump.o -I$gtm_inc >&! compile.out && \
-	$gt_ld_linker $gt_ld_options_common -o svndump svndump.o -L$gtm_dist/obj -lmumps -lstub $gt_ld_sysrtns $gt_ld_syslibs >&! link.out
+	$gt_ld_linker $gt_ld_options_common -o svndump svndump.o -L$gtm_dist/obj -lmumps $gt_ld_sysrtns $gt_ld_syslibs >&! link.out
 if ( ! -e svndump ) then
 	echo "Compilation of svndump failed, exiting"
 	exit 0


### PR DESCRIPTION

* Fix v53003/D9I10002703 subtest failure now that gtm_dist env var affects startup of
  DBCERTIFY, GTCM_GNP_SERVER and GTCM_SERVER (due to dlopen of $gtm_dist/libgtmshr.so)
* Fix errors/test_fao subtest since libgnpclient and libcmisockettcp are no longer in the build (moved to libmumps)
* Fix v62001/hash and v62002/zwritesvn subtest failures since libstub is no longer in the build (moved to libmumps)