### PR TITLE
[#59] Fix java/callins test failure due to recent code changes that now correctly issue a QUITARGREQD error

### DIFF
--- a/java/inref/com.test.ji.TestCI.java
+++ b/java/inref/com.test.ji.TestCI.java
@@ -1951,16 +1951,7 @@ public class TestCI {
 
 				@Override
 				public String getJavaResponse() {
-					String retValue;
-					if (retType == GTMType.GTM_BOOLEAN)
-						retValue = "false";
-					else if (retType == GTMType.GTM_INTEGER || retType == GTMType.GTM_LONG)
-						retValue = "0";
-					else if (retType == GTMType.GTM_FLOAT || retType == GTMType.GTM_DOUBLE)
-						retValue = "0.0";
-					else	/* JAVA_STRING or JAVA_BYTE_ARRAY */
-						retValue = "";
-					return retValue + "\n";
+					return "150374554,%GTM-E-QUITARGREQD, Quit from an extrinsic must have an argument" + "\n";
 				}
 			};
 		}


### PR DESCRIPTION
Test 25 in the java/callins subtest defines the following call-in table

```
Test25.ci
----------
lbl0:	gtm_jboolean_t lbl0^test25()
lbl1:	gtm_jint_t lbl1^test25()
lbl2:	gtm_jlong_t lbl2^test25()
lbl3:	gtm_jfloat_t lbl3^test25()
lbl4:	gtm_jdouble_t lbl4^test25()
lbl5:	gtm_jstring_t lbl5^test25()
lbl6:	gtm_jbyte_array_t lbl6^test25()

And the corresponding M program is the following.

test25.m
---------
lbl0()
	quit
lbl1()
	quit
lbl2()
	quit
lbl3()
	quit
lbl4()
	quit
lbl5()
	quit
lbl6()
	quit
```

Each of the function prototypes in Test25.ci have a return value but the corresponding M functions
do a quit without any value. So this is a case where a QUITARGREQD error should be issued.
Until recently this error was not being issued. But a recent #59 commit fixed this behavior by
invoking op_exfunret() in ydb_cij(). Therefore this test program is now fixed to generate a new
reference file.