### PR TITLE
Fix v62000/gtm7926rcvr test failure; due to YottaDB/YottaDB#33 a DLLN…

### DIFF
--- a/v62000/outref/gtm7926rcvr.txt
+++ b/v62000/outref/gtm7926rcvr.txt
@@ -4,9 +4,11 @@ mumps.gld
 Using: ##SOURCE_PATH##/mupip
 mumps.dat
 ###################################################################
-%GTM-E-GTMDISTUNVERIF, Environment variable $gtm_dist (##GTM_LIBRARY_PATH##/##FILTERED##PRIORVER##/pro) could not be verified against the executables path (##SOURCE_PATH##/mupip)
+%GTM-E-DLLNORTN, Failed to look up the location of the symbol mupip_main
+%GTM-E-TEXT, ##GTM_LIBRARY_PATH##/##FILTERED##PRIORVER##/pro/libgtmshr##TEST_SHL_SUFFIX##: undefined symbol: mupip_main
 ###################################################################
-%GTM-E-GTMDISTUNVERIF, Environment variable $gtm_dist (##GTM_LIBRARY_PATH##/##FILTERED##PRIORVER##/pro) could not be verified against the executables path (mupip)
+%GTM-E-DLLNORTN, Failed to look up the location of the symbol mupip_main
+%GTM-E-TEXT, ##GTM_LIBRARY_PATH##/##FILTERED##PRIORVER##/pro/libgtmshr##TEST_SHL_SUFFIX##: undefined symbol: mupip_main
 ##SOURCE_PATH##/mupip
 ##SOURCE_PATH##/mupip integ -REG *
 No errors detected by integ.


### PR DESCRIPTION
…ORTN error is first issued instead of GTMDISTUNVERIF so fix reference file to reflect new behavior