### PR TITLE
Fix FILTERTIMEDOUT test failures on Linux/ARM by setting a bigger tim…

### DIFF
--- a/com/set_gtm_machtype.csh
+++ b/com/set_gtm_machtype.csh
@@ -58,7 +58,7 @@ if (($gtm_test_machtype == "ix86") || ($gtm_test_machtype == "armv7l")) then
 	setenv gtm_platform_size 32
 	# Increase replication filter timeout on the ARM as we have seen test failures
 	# due to FILTERTIMEDOUT error in the source server log.
-	setenv gtm_repl_filter_timeout 256      # in seconds. This is 4 times default of 64 seconds
+	setenv ydb_repl_filter_timeout 256      # in seconds. This is 4 times default of 64 seconds
 else
 	setenv gtm_platform_size 64
 endif

--- a/com/set_gtm_machtype.csh
+++ b/com/set_gtm_machtype.csh
@@ -56,6 +56,9 @@ endif
 # Set the variable for 32 bit architectures. Adding more 32bit platforms isn't likely
 if (($gtm_test_machtype == "ix86") || ($gtm_test_machtype == "armv7l")) then
 	setenv gtm_platform_size 32
+	# Increase replication filter timeout on the ARM as we have seen test failures
+	# due to FILTERTIMEDOUT error in the source server log.
+	setenv gtm_repl_filter_timeout 256      # in seconds. This is 4 times default of 64 seconds
 else
 	setenv gtm_platform_size 64
 endif


### PR DESCRIPTION
…eout of 256 seconds (default is 64 seconds) using new env var gtm_repl_filter_timeout (introduced in YottaDB/YottaDB#109)