### PR TITLE
Fix v62000/gtm7926rcvr subtest due to DLLNOOPEN/ELFCLASS32 error (ins…

### DIFF
--- a/v62000/u_inref/gtm7926rcvr.csh
+++ b/v62000/u_inref/gtm7926rcvr.csh
@@ -28,7 +28,7 @@ setenv test_encryption NON_ENCRYPT
 source $gtm_tst/com/portno_acquire.csh >>& portno.out
 
 # Get an alternate prior version
-set prior_ver = `$gtm_tst/com/random_ver.csh -lte V61000`
+set prior_ver = `$gtm_tst/com/random_ver.csh -lte V61000 -gte V54001`
 if ("$prior_ver" =~ "*-E-*") then
         echo "No prior versions available: $prior_ver"
         exit -1


### PR DESCRIPTION
…tead of expected DLLNORTN error) due to 32-bit V53002 being chosen as random prior version