### PR TITLE
Fix triggers test failure (various subtests) in pro due to code merge of GT.M V6.3-003 into YottaDB mainline

### DIFF
--- a/com/trigupgrd_test.csh
+++ b/com/trigupgrd_test.csh
@@ -4,7 +4,7 @@
 # Copyright (c) 2014-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #                                                               #
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -140,7 +140,7 @@ CAT_EOF
 	$MUPIP TRIGGER -UPGRADE >& $curline.newver.trigupgrd.out
 	$GTM << GTM_EOF >& $curline.newver.out
 		write \$zver,!
-		set \$etrap="write TRIGUPGRD_TEST-E-FAIL : Fail at trigger select stage. See $curpwd/$curline.newver.out,! zhalt 1"
+		set \$etrap="write ""TRIGUPGRD_TEST-E-FAIL : Fail at trigger select stage. See $curpwd/$curline.newver.out"",! zhalt 1"
 		set file="$curline.newver.trig_select"
 		open file:(newversion)
 		use file

--- a/triggers/outref/gtm7083.txt
+++ b/triggers/outref/gtm7083.txt
@@ -25,6 +25,7 @@ $gtm_exe/mumps -run %XCMD 'zprint ^x#'
 unset verbose
 # The below that does not require trigger access should work fine
 $LKE show -all
+##TEST_AWK%GTM-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/(160|213); LOCK slots in use: 0/(120|184); name space not full
 %GTM-I-NOLOCKMATCH, No matching locks were found in DEFAULT
 %GTM-I-LOCKSPACEUSE, Estimated free lock space: 100% of 40 pages
 $DSE dump -block=3 > & ! dsedumpbl3.out


### PR DESCRIPTION
The related V6.3-003 code changes are

SET $ZTRAP or SET $ETRAP is now checked for syntax errors (GTM-8769).
LKE SHOW includes a LOCKSPACEINFO message even if the lock space is not full (GTM-8680).