### PR TITLE
[#97] Add r120/msgprefix subtest (tests YottaDB/YottaDB#97); Few other fixes

### DIFF
--- a/com/send_env.csh
+++ b/com/send_env.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2002-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -22,7 +25,7 @@ if ($HOSTOS == "SunOS") then
 	setenv | $grep -E "gtm_linktmpdir" | sed 's/\\\075/=/g' | sed 's/'$user'/$user/' >>&! ${TMP_FILE_PREFIX}_env_${USER}.txt
 
 else
-	setenv | $grep -E "^gtm|^acc_meth|^tst|^test|^PRI|^SEC|^remote_ver|^remote_image|^user|^mailing_list" | $grep -vE "gtm_icu_version" >&! ${TMP_FILE_PREFIX}_env_${USER}.txt
+	setenv | $grep -E "^ydb|^gtm|^acc_meth|^tst|^test|^PRI|^SEC|^remote_ver|^remote_image|^user|^mailing_list" | $grep -vE "gtm_icu_version" >&! ${TMP_FILE_PREFIX}_env_${USER}.txt
 	setenv | $grep -E "gtm_linktmpdir" | sed 's/'$user'/$user/' >>&! ${TMP_FILE_PREFIX}_env_${USER}.txt
 	# Fix user specific environment variables
 endif

--- a/r120/instream.csh
+++ b/r120/instream.csh
@@ -23,6 +23,7 @@
 # zeofprocfs        [nars]  Test that $ZEOF is correctly set after READ commands on procfs files (e.g. /proc/$J/io)
 # libyottadb        [nars]  Test that libgtmshr.so/libgtmutil.so are soft links to libyottadb.so/libyottadbutil.so
 # zstepoveroutof    [nars]  Test that ZSTEP OVER and ZSTEP OUTOF work if an extrinsic function returns using QUIT @ syntax
+# msgprefix         [nars]  Test of <ydb_msgprefix> environment variable
 #-------------------------------------------------------------------------------------
 
 echo "r120 test starts..."
@@ -30,7 +31,7 @@ echo "r120 test starts..."
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
 setenv subtest_list_non_replic "zindcacheoverflow largelvarray gctest patnotfound readtimeout miximage zeofprocfs"
-setenv subtest_list_non_replic "$subtest_list_non_replic libyottadb zstepoveroutof"
+setenv subtest_list_non_replic "$subtest_list_non_replic libyottadb zstepoveroutof msgprefix"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/r120/outref/msgprefix.txt
+++ b/r120/outref/msgprefix.txt
@@ -1,0 +1,33 @@
+###################################################################
+# Test of <ydb_msgprefix> environment variable
+###################################################################
+
+# Test that ydb_msgprefix undefined defaults to YDB
+%YDB-I-BREAKZST, Break instruction encountered during ZSTEP action
+
+# Test ydb_msgprefix set to strings of length 0, 3, 31, 32. For 32, the value is ignored. For < 32, it is honored.
+#   env ydb_msgprefix=
+%-I-BREAKZST, Break instruction encountered during ZSTEP action
+#   env ydb_msgprefix=abc
+%abc-I-BREAKZST, Break instruction encountered during ZSTEP action
+#   env ydb_msgprefix=ABCDEFGHIJKLMNOPWRSTUVWXYZ12345
+%ABCDEFGHIJKLMNOPWRSTUVWXYZ12345-I-BREAKZST, Break instruction encountered during ZSTEP action
+#   env ydb_msgprefix=ABCDEFGHIJKLMNOPWRSTUVWXYZ123456
+%YDB-I-BREAKZST, Break instruction encountered during ZSTEP action
+
+# Test that ydb_msgprefix set to some value (###) does not affect error messages in .msg files other than merrors.msg.
+#   Test Error codes in cmerrors.msg : INVPROT and CMSYSSRV
+%GTCM-E-INVPROT, Invalid protocol specified by remote partner
+%GTCM-E-CMSYSSRV, Error doing system service, status:
+#   Test Error codes in cmierrors.msg : DCNINPROG and REASON_CONFIRM
+%CMI-F-DCNINPROG, Attempt to initiate operation while disconnect was in progress
+%CMI-E-REASON_CONFIRM, Confirm
+#   Test Error codes in gdeerrors.msg : INPINTEG and NOPERCENTY
+%GDE-F-INPINTEG, Input integrity error -- aborting load
+%GDE-E-NOPERCENTY, ^%Y* is a reserved global name in YottaDB
+#   Test Error codes in merrors.msg : BREAKZST and STPCRIT
+%###-I-BREAKZST, Break instruction encountered during ZSTEP action
+%###-E-STPCRIT, String pool space critical
+#   Test Error codes in ydberrors.msg : QUERY2 and MIXIMAGE
+%YDB-E-QUERY2, Invalid second argument to $QUERY. Must be -1 or 1.
+%YDB-E-MIXIMAGE, Cannot load  image on process that already has  image loaded

--- a/r120/outref/outref.txt
+++ b/r120/outref/outref.txt
@@ -15,5 +15,6 @@ PASS from miximage
 PASS from zeofprocfs
 PASS from libyottadb
 PASS from zstepoveroutof
+PASS from msgprefix
 ##ALLOW_OUTPUT REPLIC
 r120 test DONE.

--- a/r120/u_inref/msgprefix.csh
+++ b/r120/u_inref/msgprefix.csh
@@ -1,0 +1,49 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+$echoline
+echo "# Test of <ydb_msgprefix> environment variable"
+$echoline
+#
+echo ""
+echo "# Test that ydb_msgprefix undefined defaults to YDB"
+unsetenv ydb_msgprefix
+$gtm_exe/mumps -run %XCMD 'zmessage 150372371'
+
+echo ""
+echo "# Test ydb_msgprefix set to strings of length 0, 3, 31, 32. For 32, the value is ignored. For < 32, it is honored."
+foreach value ("" "abc" "ABCDEFGHIJKLMNOPWRSTUVWXYZ12345" "ABCDEFGHIJKLMNOPWRSTUVWXYZ123456")
+	echo "#   env ydb_msgprefix=$value"
+	setenv ydb_msgprefix $value
+	$gtm_exe/mumps -run %XCMD 'zmessage 150372371'
+end
+
+echo ""
+echo "# Test that ydb_msgprefix set to some value (###) does not affect error messages in .msg files other than merrors.msg."
+setenv ydb_msgprefix "###"
+echo "#   Test Error codes in cmerrors.msg : INVPROT and CMSYSSRV"
+$gtm_exe/mumps -run %XCMD 'zmessage 150568970'
+$gtm_exe/mumps -run %XCMD 'zmessage 150569010'
+echo "#   Test Error codes in cmierrors.msg : DCNINPROG and REASON_CONFIRM"
+$gtm_exe/mumps -run %XCMD 'zmessage 150634508'
+$gtm_exe/mumps -run %XCMD 'zmessage 150634698'
+echo "#   Test Error codes in gdeerrors.msg : INPINTEG and NOPERCENTY"
+$gtm_exe/mumps -run %XCMD 'zmessage 150503508'
+$gtm_exe/mumps -run %XCMD 'zmessage 150504114'
+echo "#   Test Error codes in merrors.msg : BREAKZST and STPCRIT"
+$gtm_exe/mumps -run %XCMD 'zmessage 150372371'
+$gtm_exe/mumps -run %XCMD 'zmessage 150384274'
+echo "#   Test Error codes in ydberrors.msg : QUERY2 and MIXIMAGE"
+$gtm_exe/mumps -run %XCMD 'zmessage 151027722'
+$gtm_exe/mumps -run %XCMD 'zmessage 151027730'
+

--- a/v53003/outref/D9I10002703.txt
+++ b/v53003/outref/D9I10002703.txt
@@ -126,6 +126,7 @@ Testing buffer overflow for environment variable : <gtm_utfcgr_strings>
 Testing buffer overflow for environment variable : <gtm_utfcgr_string_groups>
 Testing buffer overflow for environment variable : <gtm_string_pool_limit>
 Testing buffer overflow for environment variable : <ydb_repl_filter_timeout>
+Testing buffer overflow for environment variable : <ydb_msgprefix>
 # Stop background GT.M updates
 
 GTM>

--- a/v53003/outref/errors_ydb_msgprefix.txt
+++ b/v53003/outref/errors_ydb_msgprefix.txt
@@ -1,0 +1,16 @@
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_msgprefix/ydb_msgprefix_DBCERTIFY.log
+%YDB-E-BADDBVER, Incorrect database version: 
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_msgprefix/ydb_msgprefix_GTCM_GNP_SERVER2.log
+%YDB-F-FORCEDHALT, Image HALTed by MUPIP STOP
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_msgprefix/ydb_msgprefix_MUPIP_DOWNGRADE.log
+##TEST_AWK%YDB-E-SYSCALL, Error received from system call ftok.. -- called from module .*/mu_all_version_standalone.c at line [1-9][0-9]*
+%SYSTEM-E-ENO2, No such file or directory
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_msgprefix/ydb_msgprefix_MUPIP_JOURNAL_ROLLBACK.log
+##TEST_AWK%YDB-E-MUJPOOLRNDWNFL, Jnlpool section \(id = [0-9]*\) belonging to the replication instance ##TEST_PATH##/mumps.repl rundown failed
+%YDB-E-MUNOACTION, MUPIP unable to perform requested action
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_msgprefix/ydb_msgprefix_MUPIP_RUNDOWN.log
+##TEST_AWK%YDB-E-MUJPOOLRNDWNFL, Jnlpool section \(id = [0-9]*\) belonging to the replication instance ##TEST_PATH##/mumps.repl rundown failed
+%YDB-W-MUNOTALLSEC, WARNING: not all global sections accessed were successfully rundown
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_msgprefix/ydb_msgprefix_MUPIP_UPGRADE.log
+##TEST_AWK%YDB-E-SYSCALL, Error received from system call ftok.. -- called from module .*/mu_all_version_standalone.c at line [1-9][0-9]*
+%SYSTEM-E-ENO2, No such file or directory


### PR DESCRIPTION
Enhance send_env.csh to send all env vars starting with <ydb> to remote side (to ensure multi-host
tests pick up env vars like ydb_msgprefix specified on local side)

Fix v53003/D9I10002703 subtest failure (take new ydb_msgprefix env var into account)