### PR TITLE
[#94] Add r120/ydbdist subtest (tests YottaDB/YottaDB#94); Fixes to few other pre-existing tests

### DIFF
--- a/r120/instream.csh
+++ b/r120/instream.csh
@@ -24,6 +24,7 @@
 # libyottadb        [nars]  Test that libgtmshr.so/libgtmutil.so are soft links to libyottadb.so/libyottadbutil.so
 # zstepoveroutof    [nars]  Test that ZSTEP OVER and ZSTEP OUTOF work if an extrinsic function returns using QUIT @ syntax
 # msgprefix         [nars]  Test of <ydb_msgprefix> environment variable
+# ydbdist           [nars]  Test of <ydb_dist/gtm_dist> env vars and how they affect how executables in $ydb_dist are invoked
 #-------------------------------------------------------------------------------------
 
 echo "r120 test starts..."
@@ -31,7 +32,7 @@ echo "r120 test starts..."
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
 setenv subtest_list_non_replic "zindcacheoverflow largelvarray gctest patnotfound readtimeout miximage zeofprocfs"
-setenv subtest_list_non_replic "$subtest_list_non_replic libyottadb zstepoveroutof msgprefix"
+setenv subtest_list_non_replic "$subtest_list_non_replic libyottadb zstepoveroutof msgprefix ydbdist"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/r120/outref/outref.txt
+++ b/r120/outref/outref.txt
@@ -16,5 +16,6 @@ PASS from zeofprocfs
 PASS from libyottadb
 PASS from zstepoveroutof
 PASS from msgprefix
+PASS from ydbdist
 ##ALLOW_OUTPUT REPLIC
 r120 test DONE.

--- a/r120/outref/ydbdist.txt
+++ b/r120/outref/ydbdist.txt
@@ -1,0 +1,217 @@
+###################################################################
+# Test of <ydb_dist/gtm_dist> env vars and how they affect how executables in ##SOURCE_PATH## are invoked
+###################################################################
+
+# Test 1 : mumps/mupip/dse/lke etc. invoked through a soft link of a different name should work
+#  Invoking executable : mumps
+What file: %GTM-E-FILENOTFND, File  not found
+#  Invoking executable : mupip
+MUPIP> #  Invoking executable : dbcertify
+%GTM-E-CLIERR, No parameters specified
+#  Invoking executable : dse
+%GTM-E-ZGBLDIRACC, Cannot access global directory ##TEST_PATH##/mumps.gld.  Cannot continue.
+%SYSTEM-E-ENO2, No such file or directory
+#  Invoking executable : ftok
+
+Usage:
+	##SOURCE_PATH##/ftok [-id=<number>] <file1> <file2> ... <filen>
+
+Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
+
+#  Invoking executable : geteuid
+other
+#  Invoking executable : gtcm_gnp_server
+##TEST_AWK%GTM-I-FILERENAME, File ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log is renamed to ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log_.*
+#  Invoking executable : gtcm_pkdisp
+#  Invoking executable : gtcm_play
+0 seconds connect time
+0 OMI transactions
+0 OMI errors
+0 bytes recv'd
+0 bytes sent
+#  Invoking executable : gtcm_server
+%GTM-E-GETADDRINFO, Error in getting address info
+%GTM-I-TEXT, Name or service not known
+#  Invoking executable : gtcm_shmclean
+If this program is used to remove shared memory from running
+processes, it will cause the program to fail. Please make
+sure all GTM processes have been shut down cleanly before running
+this program.
+
+Do you want to contine? (y or n)  Error while reading response from user. Exiting
+#  Invoking executable : gtmsecshr
+#  Invoking executable : lke
+%GTM-E-ZGBLDIRACC, Cannot access global directory ##TEST_PATH##/mumps.gld.  Cannot continue.
+%SYSTEM-E-ENO2, No such file or directory
+#  Invoking executable : semstat2
+##TEST_PATH##/mysemstat2:  Report information about semaphores
+
+Usage-
+	##TEST_PATH##/mysemstat2 <semid1> <semid2> ... <semidn>
+
+information returned for each semaphore in set:
+	semval		current value of semaphore
+	semncnt		# of procs waiting for semval to increase
+	semzcnt		# of procs waiting for semval to become zero
+	sempid		PID of last proc performing operation on semaphore
+
+# Test 2 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that also contains a copy of libyottadb##TEST_SHL_SUFFIX## should work
+#          Previously this would issue an IMAGENAME error for the "mumps" case. That is no longer the case
+#  Invoking executable : mumps
+What file: %GTM-E-FILENOTFND, File  not found
+#  Invoking executable : mupip
+MUPIP> #  Invoking executable : dbcertify
+%GTM-E-CLIERR, No parameters specified
+#  Invoking executable : dse
+%GTM-E-ZGBLDIRACC, Cannot access global directory ##TEST_PATH##/mumps.gld.  Cannot continue.
+%SYSTEM-E-ENO2, No such file or directory
+#  Invoking executable : ftok
+
+Usage:
+	##TEST_PATH##/myftok [-id=<number>] <file1> <file2> ... <filen>
+
+Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
+
+#  Invoking executable : geteuid
+other
+#  Invoking executable : gtcm_gnp_server
+##TEST_AWK%GTM-I-FILERENAME, File ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log is renamed to ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log_.*
+#  Invoking executable : gtcm_pkdisp
+#  Invoking executable : gtcm_play
+0 seconds connect time
+0 OMI transactions
+0 OMI errors
+0 bytes recv'd
+0 bytes sent
+#  Invoking executable : gtcm_server
+%GTM-E-GETADDRINFO, Error in getting address info
+%GTM-I-TEXT, Name or service not known
+#  Invoking executable : gtcm_shmclean
+If this program is used to remove shared memory from running
+processes, it will cause the program to fail. Please make
+sure all GTM processes have been shut down cleanly before running
+this program.
+
+Do you want to contine? (y or n)  Error while reading response from user. Exiting
+#  Invoking executable : gtmsecshr
+#  Invoking executable : lke
+%GTM-E-ZGBLDIRACC, Cannot access global directory ##TEST_PATH##/mumps.gld.  Cannot continue.
+%SYSTEM-E-ENO2, No such file or directory
+#  Invoking executable : semstat2
+##TEST_PATH##/mysemstat2:  Report information about semaphores
+
+Usage-
+	##TEST_PATH##/mysemstat2 <semid1> <semid2> ... <semidn>
+
+information returned for each semaphore in set:
+	semval		current value of semaphore
+	semncnt		# of procs waiting for semval to increase
+	semzcnt		# of procs waiting for semval to become zero
+	sempid		PID of last proc performing operation on semaphore
+
+# Test 3 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that does not also contain a copy of libyottadb##TEST_SHL_SUFFIX## should issue DLLNOOPEN error
+#          Previously this would issue a GTMDISTUNVERIF error.
+#  Invoking executable : mumps
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : mupip
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : dbcertify
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : dse
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : ftok
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : geteuid
+other
+#  Invoking executable : gtcm_gnp_server
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : gtcm_pkdisp
+#  Invoking executable : gtcm_play
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : gtcm_server
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : gtcm_shmclean
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : gtmsecshr
+#  Invoking executable : lke
+%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
+%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
+#  Invoking executable : semstat2
+##TEST_PATH##/mysemstat2:  Report information about semaphores
+
+Usage-
+	##TEST_PATH##/mysemstat2 <semid1> <semid2> ... <semidn>
+
+information returned for each semaphore in set:
+	semval		current value of semaphore
+	semncnt		# of procs waiting for semval to increase
+	semzcnt		# of procs waiting for semval to become zero
+	sempid		PID of last proc performing operation on semaphore
+
+# Test 4 : mumps/mupip/dse/lke etc. invoked from a current directory where they do not exist, but are found in $PATH, should work
+#  Invoking executable : mumps
+What file: %GTM-E-FILENOTFND, File  not found
+#  Invoking executable : mupip
+MUPIP> #  Invoking executable : dbcertify
+%GTM-E-CLIERR, No parameters specified
+#  Invoking executable : dse
+%GTM-E-ZGBLDIRACC, Cannot access global directory ##TEST_PATH##/mumps.gld.  Cannot continue.
+%SYSTEM-E-ENO2, No such file or directory
+#  Invoking executable : ftok
+
+Usage:
+	##SOURCE_PATH##/ftok [-id=<number>] <file1> <file2> ... <filen>
+
+Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
+
+#  Invoking executable : geteuid
+other
+#  Invoking executable : gtcm_gnp_server
+##TEST_AWK%GTM-I-FILERENAME, File ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log is renamed to ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log_.*
+#  Invoking executable : gtcm_pkdisp
+#  Invoking executable : gtcm_play
+0 seconds connect time
+0 OMI transactions
+0 OMI errors
+0 bytes recv'd
+0 bytes sent
+#  Invoking executable : gtcm_server
+%GTM-E-GETADDRINFO, Error in getting address info
+%GTM-I-TEXT, Name or service not known
+#  Invoking executable : gtcm_shmclean
+If this program is used to remove shared memory from running
+processes, it will cause the program to fail. Please make
+sure all GTM processes have been shut down cleanly before running
+this program.
+
+Do you want to contine? (y or n)  Error while reading response from user. Exiting
+#  Invoking executable : gtmsecshr
+#  Invoking executable : lke
+%GTM-E-ZGBLDIRACC, Cannot access global directory ##TEST_PATH##/mumps.gld.  Cannot continue.
+%SYSTEM-E-ENO2, No such file or directory
+#  Invoking executable : semstat2
+semstat2:  Report information about semaphores
+
+Usage-
+	semstat2 <semid1> <semid2> ... <semidn>
+
+information returned for each semaphore in set:
+	semval		current value of semaphore
+	semncnt		# of procs waiting for semval to increase
+	semzcnt		# of procs waiting for semval to become zero
+	sempid		PID of last proc performing operation on semaphore
+
+# Test 5 : gtmsecshr issues a SECSHRNOYDBDIST error if ydb_dist env var is not set
+----------
+Error SECSHRNOYDBDIST seen in syslog1.txt as expected:
+##TEST_AWK.* GTMSECSHRINIT\[.*\]: %GTM-E-SECSHRNOYDBDIST, ydb_dist env var does not exist. gtmsecshr will not be started
+----------

--- a/r120/u_inref/ydbdist.csh
+++ b/r120/u_inref/ydbdist.csh
@@ -1,0 +1,78 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+set saveydbdist = $ydb_dist
+unsetenv ydb_dist
+unsetenv gtm_dist
+set executables = "mumps mupip dbcertify dse ftok geteuid gtcm_gnp_server gtcm_pkdisp gtcm_play gtcm_server gtcm_shmclean gtmsecshr lke semstat2"
+
+$echoline
+echo "# Test of <ydb_dist/gtm_dist> env vars and how they affect how executables in $saveydbdist are invoked"
+$echoline
+#
+echo ""
+echo "# Test 1 : mumps/mupip/dse/lke etc. invoked through a soft link of a different name should work"
+foreach exe ($executables)
+	set newexe = "`pwd`/my$exe"
+	echo "#  Invoking executable : $exe"
+	ln -s $saveydbdist/$exe $newexe
+	$newexe
+	wait	# in case the above starts any background processes
+	rm -f $newexe
+end
+
+echo ""
+echo '# Test 2 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that also contains a copy of libyottadb.so should work'
+echo '#          Previously this would issue an IMAGENAME error for the "mumps" case. That is no longer the case'
+cp $saveydbdist/libyottadb.so .	# needed by those executables that dlopen libyottadb.so (mumps, dse, mupip etc.)
+foreach exe ($executables)
+	set newexe = "`pwd`/my$exe"
+	echo "#  Invoking executable : $exe"
+	cp $saveydbdist/$exe $newexe
+	$newexe
+	wait	# in case the above starts any background processes
+	rm -f $newexe
+end
+rm -f libyottadb.so
+
+echo ""
+echo '# Test 3 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that does not also contain a copy of libyottadb.so should issue DLLNOOPEN error'
+echo '#          Previously this would issue a GTMDISTUNVERIF error.'
+foreach exe ($executables)
+	set newexe = "`pwd`/my$exe"
+	echo "#  Invoking executable : $exe"
+	cp $saveydbdist/$exe $newexe
+	$newexe
+	wait	# in case the above starts any background processes
+	rm -f $newexe
+end
+
+echo ""
+echo '# Test 4 : mumps/mupip/dse/lke etc. invoked from a current directory where they do not exist, but are found in $PATH, should work'
+set origpath = ($path)
+set path = ($origpath $saveydbdist)
+foreach exe ($executables)
+	echo "#  Invoking executable : $exe"
+	$exe
+	wait	# in case the above starts any background processes
+end
+set path = ($origpath)
+
+echo ""
+echo '# Test 5 : gtmsecshr issues a SECSHRNOYDBDIST error if ydb_dist env var is not set'
+sleep 1	# sleep to ensure syslog_start is a different time than the time previous tests ran (as they also produce SECSHRNOYDBDIST message)
+set syslog_start = `date +"%b %e %H:%M:%S"`
+$saveydbdist/gtmsecshr
+$gtm_tst/com/getoper.csh "$syslog_start" "" "syslog1.txt" "" "SECSHRNOYDBDIST"
+$gtm_tst/com/check_error_exist.csh syslog1.txt SECSHRNOYDBDIST
+

--- a/r120/u_inref/ydbdist.csh
+++ b/r120/u_inref/ydbdist.csh
@@ -27,7 +27,6 @@ foreach exe ($executables)
 	echo "#  Invoking executable : $exe"
 	ln -s $saveydbdist/$exe $newexe
 	$newexe
-	wait	# in case the above starts any background processes
 	rm -f $newexe
 end
 
@@ -40,7 +39,6 @@ foreach exe ($executables)
 	echo "#  Invoking executable : $exe"
 	cp $saveydbdist/$exe $newexe
 	$newexe
-	wait	# in case the above starts any background processes
 	rm -f $newexe
 end
 rm -f libyottadb.so
@@ -53,7 +51,6 @@ foreach exe ($executables)
 	echo "#  Invoking executable : $exe"
 	cp $saveydbdist/$exe $newexe
 	$newexe
-	wait	# in case the above starts any background processes
 	rm -f $newexe
 end
 
@@ -63,8 +60,12 @@ set origpath = ($path)
 set path = ($origpath $saveydbdist)
 foreach exe ($executables)
 	echo "#  Invoking executable : $exe"
-	$exe
-	wait	# in case the above starts any background processes
+	# Although we redirect the below to a file and immediately cat the file, not redirecting the output
+	# results in some test output reordering issues. Not exactly sure what the cause is. But since redirection
+	# addresses that issue, it is not further investigated. Use logx (not log) to avoid test error framework
+	# from signaling errors in these files at the end of the test.
+	$exe >& $exe.logx
+	cat $exe.logx
 end
 set path = ($origpath)
 

--- a/v42000/outref/startup_check.txt
+++ b/v42000/outref/startup_check.txt
@@ -1,2 +1,6 @@
-%GTM-E-GTMDISTUNDEF, Environment variable $gtm_dist is not defined
+
+GTM>
+Testing YottaDB Startup check ...
+
+GTM>
 TEST PASSED

--- a/v42000/u_inref/startup_check.csh
+++ b/v42000/u_inref/startup_check.csh
@@ -1,11 +1,21 @@
-#! /usr/local/bin/tcsh -f
-#!
-#
-unsetenv test_replic   
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+unsetenv test_replic
 unsetenv gtm_exe
+unsetenv ydb_dist
 unsetenv gtm_dist
 $GTM << aaa
-W "Testing GT.M Startup check ...",!
+W "Testing YottaDB Startup check ...",!
 aaa
 find . -type f -a \( -name 'core*' -o -name 'gtmcore*' \) -print >& CORE.list
 if !($status) then

--- a/v53003/outref/D9I10002703.txt
+++ b/v53003/outref/D9I10002703.txt
@@ -20,6 +20,7 @@ GTM>
 # Now determine list of environment variables used by GT.M from the header file gtm_logicals.h
 -------------------------------------------------------------------------------------------
 Testing buffer overflow for environment variable : <gtm_dist>
+Testing buffer overflow for environment variable : <ydb_dist>
 Testing buffer overflow for environment variable : <gtm_blkupgrade_flag>
 Testing buffer overflow for environment variable : <gtm_dbfilext_syslog_disable>
 Testing buffer overflow for environment variable : <gtm_env_translate>

--- a/v53003/outref/errors_ydb_dist.txt
+++ b/v53003/outref/errors_ydb_dist.txt
@@ -1,14 +1,14 @@
-##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_DBCERTIFY.log
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_dist/ydb_dist_DBCERTIFY.log
 %GTM-E-BADDBVER, Incorrect database version: 
-##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_GTCM_GNP_SERVER2.log
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_dist/ydb_dist_GTCM_GNP_SERVER2.log
 %GTM-F-FORCEDHALT, Image HALTed by MUPIP STOP
-##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_MUPIP_DOWNGRADE.log
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_dist/ydb_dist_MUPIP_DOWNGRADE.log
 ##TEST_AWK%GTM-E-SYSCALL, Error received from system call ftok.. -- called from module .*/mu_all_version_standalone.c at line [1-9][0-9]*
 %SYSTEM-E-ENO2, No such file or directory
-##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_MUPIP_JOURNAL_ROLLBACK.log
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_dist/ydb_dist_MUPIP_JOURNAL_ROLLBACK.log
 %GTM-E-MUNOACTION, MUPIP unable to perform requested action
-##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_MUPIP_RUNDOWN.log
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_dist/ydb_dist_MUPIP_RUNDOWN.log
 %GTM-W-MUNOTALLSEC, WARNING: not all global sections accessed were successfully rundown
-##TEST_HOST_SHORT##:##TEST_PATH##/gtm_dist/gtm_dist_MUPIP_UPGRADE.log
+##TEST_HOST_SHORT##:##TEST_PATH##/ydb_dist/ydb_dist_MUPIP_UPGRADE.log
 ##TEST_AWK%GTM-E-SYSCALL, Error received from system call ftok.. -- called from module .*/mu_all_version_standalone.c at line [1-9][0-9]*
 %SYSTEM-E-ENO2, No such file or directory

--- a/v53003/u_inref/D9I10002703.csh
+++ b/v53003/u_inref/D9I10002703.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2008-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -69,7 +72,8 @@ set command0 = "$gtm_dist/mumps -direct"
 set corecheck = "$tst_tcsh $gtm_tst/$tst/u_inref/D9I10002703_corecheck.csh"
 set maxstr = `$gtm_dist/mumps -run %XCMD 'Set $ZPiece(x,"0",9999)="" Write x,!'`
 echo "-------------------------------------------------------------------------------------------"
-foreach var ($envlist)
+# Add gtm_dist (supported for backward compatibility but absent in gtm_logicals.h) to buffer overflow check tests
+foreach var (gtm_dist $envlist)
 	setenv envvar $var
 	mkdir $envvar
 	# We do not want different output for $gtm_autorelink_keeprtn on platforms that support it and on those that do not.

--- a/v62000/outref/gtm7926callins.txt
+++ b/v62000/outref/gtm7926callins.txt
@@ -3,25 +3,36 @@ Using: ##SOURCE_PATH##/mumps -run GDE
 mumps.gld
 Using: ##SOURCE_PATH##/mupip
 mumps.dat
-This will not generate an error
-This will generate an undef error
-%GTM-E-GTMDISTUNDEF, Environment variable $gtm_dist is not defined
-This will generate a syscall error
-%GTM-E-SYSCALL, Error received from system call stat for $gtm_dist/gtmsecshr
-%SYSTEM-E-ENO2, No such file or directory
-This will not generate an error
+
+Test the JOB command execution with the correct and incorrect (null or invalid) \##SOURCE_PATH##
+###################################################################
+# Test of ydb_dist defined to a valid value. This will not generate an error
+# Test of ydb_dist undefined. This will not generate an error
+# Test of ydb_dist set to NULL. This will generate an error
+%YDB-E-LIBYOTTAMISMTCH, $ydb_dist/libyottadb##TEST_SHL_SUFFIX## (/libyottadb##TEST_SHL_SUFFIX##) does not match the shared library path (##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##)
+# Test of ydb_dist set to a non-existent path. This will generate a syscall error
+%YDB-E-LIBYOTTAMISMTCH, $ydb_dist/libyottadb##TEST_SHL_SUFFIX## (/no/such/path/libyottadb##TEST_SHL_SUFFIX##) does not match the shared library path (##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##)
+
+Test the default search path for PIPE device execution with the correct and incorrect (null or invalid) \##SOURCE_PATH##
+###################################################################
+# Test of ydb_dist defined to a valid value. This will not generate an error
 other
-This will generate an undef error
-%GTM-E-GTMDISTUNDEF, Environment variable $gtm_dist is not defined
-This will generate a syscall error
-%GTM-E-SYSCALL, Error received from system call stat for $gtm_dist/gtmsecshr
-%SYSTEM-E-ENO2, No such file or directory
-This will not generate an error
-This will generate an undef error
-%GTM-E-GTMDISTUNDEF, Environment variable $gtm_dist is not defined
-This will generate a syscall error
-%GTM-E-SYSCALL, Error received from system call stat for $gtm_dist/gtmsecshr
-%SYSTEM-E-ENO2, No such file or directory
+# Test of ydb_dist undefined. This will not generate an error
+other
+# Test of ydb_dist set to NULL. This will generate an error
+%YDB-E-LIBYOTTAMISMTCH, $ydb_dist/libyottadb##TEST_SHL_SUFFIX## (/libyottadb##TEST_SHL_SUFFIX##) does not match the shared library path (##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##)
+# Test of ydb_dist set to a non-existent path. This will generate a syscall error
+%YDB-E-LIBYOTTAMISMTCH, $ydb_dist/libyottadb##TEST_SHL_SUFFIX## (/no/such/path/libyottadb##TEST_SHL_SUFFIX##) does not match the shared library path (##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##)
+
+Test the access to gtmsecshr with the correct and incorrect (null or invalid) \##SOURCE_PATH##
+###################################################################
+# Test of ydb_dist defined to a valid value. This will not generate an error
+# Test of ydb_dist undefined. This will not generate an error
+# Test of ydb_dist set to NULL. This will generate an error
+%YDB-E-LIBYOTTAMISMTCH, $ydb_dist/libyottadb##TEST_SHL_SUFFIX## (/libyottadb##TEST_SHL_SUFFIX##) does not match the shared library path (##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##)
+# Test of ydb_dist set to a non-existent path. This will generate a syscall error
+%YDB-E-LIBYOTTAMISMTCH, $ydb_dist/libyottadb##TEST_SHL_SUFFIX## (/no/such/path/libyottadb##TEST_SHL_SUFFIX##) does not match the shared library path (##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##)
+
 ##SOURCE_PATH##/mupip
 ##SOURCE_PATH##/mupip integ -REG *
 No errors detected by integ.

--- a/v62000/outref/sym.txt
+++ b/v62000/outref/sym.txt
@@ -1,2 +1,2 @@
-/tmp/MASKED/mumps
-/tmp/MASKED/mumps
+/tmp/MASKED/mumps -run %XCMD job ^%XCMD:(output="_XCMD.mjx":cmdline="zsystem ""$ps""") for i=1:1:120 quit:$zsigproc($zjob,0) write:i=120 $ztrnlnm("testfail"),! hang 0.25
+##SOURCE_PATH##/mumps -direct zsystem "$ps"

--- a/v62000/u_inref/sym.csh
+++ b/v62000/u_inref/sym.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2014-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -35,7 +38,7 @@ env gtm_dist=$uniquepath $uniquepath/mumps -run %XCMD \
 	'job ^%XCMD:(output="_XCMD.mjx":cmdline="zsystem ""$ps""") for i=1:1:120 quit:$zsigproc($zjob,0)  write:i=120 $ztrnlnm("testfail"),! hang 0.25'
 
 # Dump the paths
-$tst_awk '$0 ~ pwd {sub(/^.* \//,"/");sub(pwd,"/tmp/MASKED",$1);print $1}' pwd=${uniquepath} _XCMD.mjx
+grep 'zsystem .*"$ps"' _XCMD.mjx | $tst_awk '{sub(/^.* \//,"/");sub(pwd,"/tmp/MASKED",$1);print $0}' pwd=${uniquepath}
 
 # Delete the symlink
 rm $uniquepath


### PR DESCRIPTION
* The main change of #94 was to ignore $ydb_dist/$gtm_dist in the environment and determine it
  based on the running executable. This is already tested in the v62000/sym and
  v42000/startup_check subtests. So that is not tested in the new r120/ydbdist subtest. Instead,
  other changes in #94 are tested there.

* Fix v62000/sym test failure ($gtm_dist is set to canonical path before JOB command now so
  adjust reference file)

* Fix v42000/startup_check test failure due to new code behavior (it is okay to have $ydb_dist
  undefined at YottaDB startup)

* Fix v62000/gtm7926callins subtest failure; Enhance the test to add the case where
  ydb_dist/gtm_dist is unset (in which case we expect them to be set inside the callin).

* Fix v53003/D9I10002703 subtest failure; Enhance it to test for ydb_dist as well as the
  deprecated gtm_dist