### PR TITLE
[#94] Fix some more E_ALL test failures due to recent YottaDB/YottaDB#94 code and test commits

### DIFF
--- a/com/gtm_env_missing_csh
+++ b/com/gtm_env_missing_csh
@@ -4,7 +4,7 @@
 # Copyright (c) 2002-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -65,5 +65,6 @@ check_setenv_echo  gt_cc_option_DDEBUG     "-DDEBUG"
 check_setenv_echo  gt_cc_option_I          "-I$gtm_inc"
 check_setenv_echo  gt_ld_option_output    "-o"
 
+setenv gtm_exe_realpath	`realpath $gtm_exe`
 setenv gtm_version_change 1	# to force gtm_env.csh to go into the codepath that initializes a lot of gt_* variables
 source $gtm_tools/gtm_env.csh

--- a/com/inref.awk
+++ b/com/inref.awk
@@ -3,7 +3,7 @@
 # Copyright (c) 2002-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -27,6 +27,7 @@ BEGIN {
 	env["gtm_tst"] = ENVIRON[ "gtm_tst" ]
 	env["in_test_path"]=env["gtm_tst"] "/" env["tst"]
 	env["gtm_exe"] = ENVIRON[ "gtm_exe" ]
+	env["gtm_exe_realpath"] = ENVIRON[ "gtm_exe_realpath" ]
 	env["gtm_root"] = ENVIRON[ "gtm_root" ]
 	env["gtm_src"] = ENVIRON[ "gtm_src" ]
 	env["home"] = ENVIRON[ "HOME" ]
@@ -94,6 +95,7 @@ function replace_flags()
 	gsub(env["gtm_tst"]"/com", "##TEST_COM_PATH##")
 	gsub(env["remote_gtm_exe"], "##REMOTE_SOURCE_PATH##")
 	gsub(env["remote_test_path"], "##REMOTE_TEST_PATH##")
+	gsub(env["gtm_exe_realpath"], "##SOURCE_REALPATH##")
 	tosub="\\y"env["tst_org_host"]"\\y" ; gsub(tosub, "##TEST_HOST##")
 	tosub="\\y"env["tst_remote_host"]"\\y" ; gsub(tosub, "##TEST_REMOTE_HOST##")
 	tosub="\\y"env["tst_remote_host_ms_1"]"\\y" ; gsub(tosub, "##TEST_REMOTE_HOST_MS_1##")

--- a/com/outref.awk
+++ b/com/outref.awk
@@ -63,6 +63,7 @@ BEGIN {
 	gtm_tst = ENVIRON[ "gtm_tst" ]
 	in_test_path = gtm_tst "/" tst
 	gtm_exe = ENVIRON[ "gtm_exe" ]
+	gtm_exe_realpath = ENVIRON[ "gtm_exe_realpath" ]
 	gtm_root = ENVIRON[ "gtm_root" ]
 	home = ENVIRON[ "HOME" ]
         tst_image = toupper(ENVIRON[ "tst_image" ])
@@ -455,6 +456,7 @@ function replace_flags()
 	gsub(/##IN_TEST_PATH##/, in_test_path)
 	gsub(/##REMOTE_SOURCE_PATH##/, remote_gtm_exe)
 	gsub(/##SOURCE_PATH##/, gtm_exe)
+	gsub(/##SOURCE_REALPATH##/, gtm_exe_realpath)
 	gsub(/##HOME_PATH##/, home)
 	gsub(/##TST_IMAGE##/, tolower(tst_image))
 	gsub(/##TEST_HOST##/, tst_org_host)

--- a/r120/outref/ydbdist.txt
+++ b/r120/outref/ydbdist.txt
@@ -1,3 +1,4 @@
+# Allocate a portno to be used for gtcm_gnp_server/gtcm_server
 ###################################################################
 # Test of <ydb_dist/gtm_dist> env vars and how they affect how executables in ##SOURCE_PATH## are invoked
 ###################################################################
@@ -14,24 +15,15 @@ MUPIP> #  Invoking executable : dbcertify
 #  Invoking executable : ftok
 
 Usage:
-	##SOURCE_PATH##/ftok [-id=<number>] <file1> <file2> ... <filen>
+	##SOURCE_REALPATH##/ftok [-id=<number>] <file1> <file2> ... <filen>
 
 Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
 
 #  Invoking executable : geteuid
 other
 #  Invoking executable : gtcm_gnp_server
-##TEST_AWK%GTM-I-FILERENAME, File ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log is renamed to ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log_.*
 #  Invoking executable : gtcm_pkdisp
-#  Invoking executable : gtcm_play
-0 seconds connect time
-0 OMI transactions
-0 OMI errors
-0 bytes recv'd
-0 bytes sent
 #  Invoking executable : gtcm_server
-%GTM-E-GETADDRINFO, Error in getting address info
-%GTM-I-TEXT, Name or service not known
 #  Invoking executable : gtcm_shmclean
 If this program is used to remove shared memory from running
 processes, it will cause the program to fail. Please make
@@ -75,17 +67,8 @@ Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
 #  Invoking executable : geteuid
 other
 #  Invoking executable : gtcm_gnp_server
-##TEST_AWK%GTM-I-FILERENAME, File ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log is renamed to ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log_.*
 #  Invoking executable : gtcm_pkdisp
-#  Invoking executable : gtcm_play
-0 seconds connect time
-0 OMI transactions
-0 OMI errors
-0 bytes recv'd
-0 bytes sent
 #  Invoking executable : gtcm_server
-%GTM-E-GETADDRINFO, Error in getting address info
-%GTM-I-TEXT, Name or service not known
 #  Invoking executable : gtcm_shmclean
 If this program is used to remove shared memory from running
 processes, it will cause the program to fail. Please make
@@ -132,9 +115,6 @@ other
 %GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
 %GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
 #  Invoking executable : gtcm_pkdisp
-#  Invoking executable : gtcm_play
-%GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
-%GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
 #  Invoking executable : gtcm_server
 %GTM-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
 %GTM-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
@@ -169,24 +149,15 @@ MUPIP> #  Invoking executable : dbcertify
 #  Invoking executable : ftok
 
 Usage:
-	##SOURCE_PATH##/ftok [-id=<number>] <file1> <file2> ... <filen>
+	##SOURCE_REALPATH##/ftok [-id=<number>] <file1> <file2> ... <filen>
 
 Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
 
 #  Invoking executable : geteuid
 other
 #  Invoking executable : gtcm_gnp_server
-##TEST_AWK%GTM-I-FILERENAME, File ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log is renamed to ##GTM_LIBRARY_PATH##/.*/log/gtcm_gnp_server.log_.*
 #  Invoking executable : gtcm_pkdisp
-#  Invoking executable : gtcm_play
-0 seconds connect time
-0 OMI transactions
-0 OMI errors
-0 bytes recv'd
-0 bytes sent
 #  Invoking executable : gtcm_server
-%GTM-E-GETADDRINFO, Error in getting address info
-%GTM-I-TEXT, Name or service not known
 #  Invoking executable : gtcm_shmclean
 If this program is used to remove shared memory from running
 processes, it will cause the program to fail. Please make
@@ -215,3 +186,4 @@ information returned for each semaphore in set:
 Error SECSHRNOYDBDIST seen in syslog1.txt as expected:
 ##TEST_AWK.* GTMSECSHRINIT\[.*\]: %GTM-E-SECSHRNOYDBDIST, ydb_dist env var does not exist. gtmsecshr will not be started
 ----------
+# Remove portno allocation file

--- a/r120/u_inref/ydbdist.csh
+++ b/r120/u_inref/ydbdist.csh
@@ -14,60 +14,115 @@
 set saveydbdist = $ydb_dist
 unsetenv ydb_dist
 unsetenv gtm_dist
-set executables = "mumps mupip dbcertify dse ftok geteuid gtcm_gnp_server gtcm_pkdisp gtcm_play gtcm_server gtcm_shmclean gtmsecshr lke semstat2"
+
+echo "# Allocate a portno to be used for gtcm_gnp_server/gtcm_server"
+source $gtm_tst/com/portno_acquire.csh >>& portno.out
+
+# "gtcm_play" is not included in the below list because it produces some timing issues in the test runs
+# Not sure what that is and since this is a helper executable for a mostly unused functionality (GTCM OMI),
+# it is not considered as essential to test that out here.
+set executables = "mumps mupip dbcertify dse ftok geteuid gtcm_gnp_server gtcm_pkdisp gtcm_server gtcm_shmclean gtmsecshr lke semstat2"
 
 $echoline
 echo "# Test of <ydb_dist/gtm_dist> env vars and how they affect how executables in $saveydbdist are invoked"
 $echoline
 #
-echo ""
-echo "# Test 1 : mumps/mupip/dse/lke etc. invoked through a soft link of a different name should work"
-foreach exe ($executables)
-	set newexe = "`pwd`/my$exe"
-	echo "#  Invoking executable : $exe"
-	ln -s $saveydbdist/$exe $newexe
-	$newexe
-	rm -f $newexe
-end
 
-echo ""
-echo '# Test 2 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that also contains a copy of libyottadb.so should work'
-echo '#          Previously this would issue an IMAGENAME error for the "mumps" case. That is no longer the case'
-cp $saveydbdist/libyottadb.so .	# needed by those executables that dlopen libyottadb.so (mumps, dse, mupip etc.)
-foreach exe ($executables)
-	set newexe = "`pwd`/my$exe"
-	echo "#  Invoking executable : $exe"
-	cp $saveydbdist/$exe $newexe
-	$newexe
-	rm -f $newexe
+foreach testcnt (1 2 3 4)
+	echo ""
+	switch ($testcnt)
+	case 1:
+		echo "# Test 1 : mumps/mupip/dse/lke etc. invoked through a soft link of a different name should work"
+		breaksw
+	case 2:
+		echo '# Test 2 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that also contains a copy of libyottadb.so should work'
+		echo '#          Previously this would issue an IMAGENAME error for the "mumps" case. That is no longer the case'
+		cp $saveydbdist/libyottadb.so .	# needed by those executables that dlopen libyottadb.so (mumps, dse, mupip etc.)
+		breaksw
+	case 3:
+		echo '# Test 3 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that does not also contain a copy of libyottadb.so should issue DLLNOOPEN error'
+		echo '#          Previously this would issue a GTMDISTUNVERIF error.'
+		breaksw
+	case 4:
+		echo '# Test 4 : mumps/mupip/dse/lke etc. invoked from a current directory where they do not exist, but are found in $PATH, should work'
+		set origpath = ($path)
+		set path = ($saveydbdist $origpath)
+		breaksw
+	endsw
+	foreach exe ($executables)
+		echo "#  Invoking executable : $exe"
+		switch ($testcnt)
+		case 1:
+			set newexe = "`pwd`/my$exe"
+			ln -s $saveydbdist/$exe $newexe
+			breaksw
+		case 2:
+			set newexe = "`pwd`/my$exe"
+			cp $saveydbdist/$exe $newexe
+			breaksw
+		case 3:
+			set newexe = "`pwd`/my$exe"
+			cp $saveydbdist/$exe $newexe
+			breaksw
+		case 4:
+			set newexe = "$exe"
+			breaksw
+		endsw
+		# gtcm_gnp_server needs log files to be specified otherwise they would go to $gtm_dist and
+		# depending on whether or not a previous log file existed, they could cause a FILERENAME message to show up or not
+		# and in turn cause test failures.
+		# gtcm_server too needs log files but more so to find out the pid of the backgrounded server
+		# and wait for it to be done before displaying the log file in the test output.
+		if (("gtcm_gnp_server" == $exe) || ("gtcm_server" == $exe)) then
+			set logfile = log_${exe}_${testcnt}.logx
+			set pidfile = ${exe}_${testcnt}.pid
+			if ("gtcm_gnp_server" == $exe) then
+				set cmd = "$newexe -log=$logfile -service=$portno"
+			else
+				set cmd = "$newexe -log $logfile -service $portno"
+			endif
+		else
+			set logfile = ""
+			set cmd = "$newexe"
+		endif
+		# Although we redirect the below to a file and immediately cat the file, not redirecting the output
+		# results in some test output reordering issues. Not exactly sure what the cause is. But since redirection
+		# addresses that issue, it is not further investigated. Use logx (not log) to avoid test error framework
+		# from signaling errors in these files at the end of the test.
+		$cmd >& ${exe}_${testcnt}.logx
+		@ exitstatus = $status
+		cat ${exe}_${testcnt}.logx
+		if (("$logfile" != "") && (0 == $exitstatus)) then
+			# Stop the backgrounded server before moving on.
+			# server was started. shut it down. pid can be found in log file.
+			$gtm_tst/com/wait_for_log.csh -log $logfile -message "pid :" -waitcreation
+			# Since ydb_dist is unset at this point, use system "head" utility rather than $head (aka head.m)
+			head -n 1 $logfile | sed 's/].*//g' | $tst_awk '{print $NF}' >! $pidfile
+			@ pid = `cat $pidfile`
+			if (0 == $pid) then
+				echo "Could not find pid from log file $logfile"
+			else
+				$kill -15 $pid
+				$gtm_tst/com/wait_for_proc_to_die.csh $pid 300
+			endif
+		endif
+		if ($newexe != $exe) then
+			rm -f $newexe
+		endif
+	end
+	switch ($testcnt)
+	case 1:
+		breaksw
+	case 2:
+		rm -f libyottadb.so
+		breaksw
+	case 3:
+		breaksw
+	case 4:
+		set path = ($origpath)
+		breaksw
+	endsw
 end
-rm -f libyottadb.so
-
-echo ""
-echo '# Test 3 : Copy of mumps/mupip/dse/lke etc. invoked from a directory that does not also contain a copy of libyottadb.so should issue DLLNOOPEN error'
-echo '#          Previously this would issue a GTMDISTUNVERIF error.'
-foreach exe ($executables)
-	set newexe = "`pwd`/my$exe"
-	echo "#  Invoking executable : $exe"
-	cp $saveydbdist/$exe $newexe
-	$newexe
-	rm -f $newexe
-end
-
-echo ""
-echo '# Test 4 : mumps/mupip/dse/lke etc. invoked from a current directory where they do not exist, but are found in $PATH, should work'
-set origpath = ($path)
-set path = ($saveydbdist $origpath)
-foreach exe ($executables)
-	echo "#  Invoking executable : $exe"
-	# Although we redirect the below to a file and immediately cat the file, not redirecting the output
-	# results in some test output reordering issues. Not exactly sure what the cause is. But since redirection
-	# addresses that issue, it is not further investigated. Use logx (not log) to avoid test error framework
-	# from signaling errors in these files at the end of the test.
-	$exe >& $exe.logx
-	cat $exe.logx
-end
-set path = ($origpath)
 
 echo ""
 echo '# Test 5 : gtmsecshr issues a SECSHRNOYDBDIST error if ydb_dist env var is not set'
@@ -76,4 +131,11 @@ set syslog_start = `date +"%b %e %H:%M:%S"`
 $saveydbdist/gtmsecshr
 $gtm_tst/com/getoper.csh "$syslog_start" "" "syslog1.txt" "" "SECSHRNOYDBDIST"
 $gtm_tst/com/check_error_exist.csh syslog1.txt SECSHRNOYDBDIST
+
+echo "# Remove portno allocation file"
+$gtm_tst/com/portno_release.csh
+
+# Restore ydb_dist/gtm_dist
+setenv ydb_dist $saveydbdist
+setenv gtm_dist $saveydbdist
 

--- a/v62000/outref/sym.txt
+++ b/v62000/outref/sym.txt
@@ -1,2 +1,2 @@
 /tmp/MASKED/mumps -run %XCMD job ^%XCMD:(output="_XCMD.mjx":cmdline="zsystem ""$ps""") for i=1:1:120 quit:$zsigproc($zjob,0) write:i=120 $ztrnlnm("testfail"),! hang 0.25
-##SOURCE_PATH##/mumps -direct zsystem "$ps"
+##SOURCE_REALPATH##/mumps -direct zsystem "$ps"

--- a/v63000/outref/gtm7291.txt
+++ b/v63000/outref/gtm7291.txt
@@ -1,10 +1,10 @@
 
 GTM>
 ##SUSPEND_OUTPUT HOST_AIX_RS6000
-##TEST_AWK.GTM-E-GDINVALID, Unrecognized Global Directory file format: ##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##, expected label: GTCGBDUNX..., found: \.ELF\.\.\.\.\.\.\.\.
+##TEST_AWK.GTM-E-GDINVALID, Unrecognized Global Directory file format: ##SOURCE_REALPATH##/libyottadb##TEST_SHL_SUFFIX##, expected label: GTCGBDUNX..., found: \.ELF\.\.\.\.\.\.\.\.
 ##SUSPEND_OUTPUT HOST_ALL
 ##ALLOW_OUTPUT HOST_AIX_RS6000
-##TEST_AWK.GTM-E-GDINVALID, Unrecognized Global Directory file format: ##SOURCE_PATH##/libyottadb##TEST_SHL_SUFFIX##, expected label: GTCGBDUNX..., found: \..\.\.....\.\.\.\.
+##TEST_AWK.GTM-E-GDINVALID, Unrecognized Global Directory file format: ##SOURCE_REALPATH##/libyottadb##TEST_SHL_SUFFIX##, expected label: GTCGBDUNX..., found: \..\.\.....\.\.\.\.
 ##ALLOW_OUTPUT HOST_ALL
 
 GTM>


### PR DESCRIPTION
* r120/ydbdist subtest : This had multiple changes.
  a) This test failed due to occasional FILERENAME messages missing in the output from the
     gtcm_gnp_server startup. This was because the default log file was in $gtm_dist and the
     rename happens only if one already existed there. To make this more deterministic, an
     explicit log file is now specified in the test output directory.
  b) Along with this, more robustness changes are done to this test to wait for backgrounded
     gtcm_gnp_server and gtcm_server to be done before moving on to the next step (removes
     further timing-related test failures).
  c) A portno is now specified at startup of gtcm_gnp_server and gtcm_server.

* r120/ydbdist, v62000/sym and v63000/gtm7291 subtest reference files.
  SOURCE_PATH usages of executables (ftok, mumps etc.) have been changed to
  SOURCE_REALPATH. This is needed because inside dlopen_libyottadb() (invoked by all
  executables in $ydb_dist at startup), the realpath of $ydb_dist is substituted as the
  pathname of argv[0] and so that is what will show up in the output file. In most platforms
  where the test runs, the $ydb_dist and its realpath would be the same path.  But in
  platforms where they are different, the test would fail. This change (from SOURCE_PATH
  to SOURCE_REALPATH) takes care of those failures. In addition, com/gtm_env_missing_csh,
  com/inref.awk and com/outref.awk were changed to introduce gtm_exe_realpath (as a parallel
  to gtm_exe) and SOURCE_REALPATH (as a parallel to SOURCE_PATH).