### PR TITLE
Fix gtcm_gnp tests (-gtcm) to work with ipv6 named hosts (e.g. $host.v46)

### DIFF
--- a/com/dbcreate.csh
+++ b/com/dbcreate.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2013-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -76,7 +79,7 @@ if (!($?test_replic)) then
    	$source_dir/send_env.csh
 	echo "Create database on GT.CM Servers ( $tst_gtcm_server_list)..."
 	set tmpenv = `$sec_shell "echo TST_REMOTE_HOST_GTCM:SEC_DIR_GTCM/"`
-	set tmpenv = `echo  $tmpenv | sed 's/ /,/g'`
+	set tmpenv = `echo  $tmpenv | sed 's/ /,/g;s/\.v46//g;s/\.v6//g;s/\.v4//g'`
 	echo "$sec_shell 'SEC_SHELL_GTCM SEC_GETENV_GTCM  ; cd SEC_DIR_GTCM ; source $source_dir/dbcreate_base.csh -GTCM_REMOTE $tmpenv $newargs'" > dbcreate.gtcm
 	$sec_shell "SEC_SHELL_GTCM SEC_GETENV_GTCM  ; cd SEC_DIR_GTCM ; source $source_dir/dbcreate_base.csh -GTCM_REMOTE $tmpenv $newargs"
 	if ($status != 0 ) exit 1


### PR DESCRIPTION


dbcreate.csh in case of a test started with -gtcm option (all the _16 tests)
invokes dbcreate_base.csh on all the hosts (client and 2 servers). If ipv6
support is detected, the test framework randomly sets the server hostname
to be ${host}.v46 or ${host}.v6 or ${host}.v4 (instead of ${host}). In this
case, dbcreate.csh on the client invokes dbcreate_base.csh on the server using
the ${host}.v46 value i.e. "dbcreate_base.csh -GTCM_REMOTE ${host}.v46:<path>"
where <path> is the path where the database files need to be created. In this
case though, dbcreate_base.csh uses an awk script dbcreate_multi.awk that tries
to match ${host}.v46 against the current host (one of the servers) and if it
does not match, it skips creating the database on this server because it think
this database is destined for the other server. This causes no databases like
b.dat, c.dat etc. to be created on the servers.

This is now fixed by passing only ${host} to dbcreate_base.csh (removing the
.v46, .v4 or .v6 hostname suffix) and that results in the appropriate databases
being created.