### PR TITLE
Env var <nfs_gtm_test> optionally controls where .sprgde files are created when test is run with -env gtm_test_spanrg=2

### DIFF
--- a/com/findsprgdefilename.csh
+++ b/com/findsprgdefilename.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2013 Fidelity Information Services, Inc	#
+# Copyright 2013 Fidelity Information Services, Inc		#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -53,7 +56,14 @@ endif
 # Set sprgdeoutdir
 # As for output directory to generate .sprgde files, always choose T9xx specific directory (do not write to generic directory)
 # as multiple folks might be running tests and we dont want race conditions during concurrent overwrites.
-set sprgdeoutdir = $gtm_test/$tst_src/sprgdedata
+# Also if the env var "nfs_gtm_test" is defined, let it control where we place the .sprgde files.
+set outdir = $gtm_test
+if ($?nfs_gtm_test) then
+	if (-e $nfs_gtm_test) then
+		set outdir = $nfs_gtm_test
+	endif
+endif
+set sprgdeoutdir = $outdir/$tst_src/sprgdedata
 # gtmtest does not own any Txxx directory.
-if ("gtmtest" == "$USER") set sprgdeoutdir = $gtm_test/sprgdedata/$tst_src
+if ("gtmtest" == "$USER") set sprgdeoutdir = $outdir/sprgdedata/$tst_src
 

--- a/com/gensprgde.csh
+++ b/com/gensprgde.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2013-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -17,6 +20,9 @@
 # gtm_test_spanreg = Decimal 3 = Binary 11 => Do     use existing .sprgde files; Do     generate .sprgde files
 
 # Attempt to generate .sprgde files.
+
+set echo
+set verbose
 
 if (! ((2 == $gtm_test_spanreg) || (3 == $gtm_test_spanreg)) || ("GT.CM" == $test_gtm_gtcm)) then
 	exit 0	# test did not want .sprgde files to be generated
@@ -48,6 +54,14 @@ if ( `expr "V61000" ">" $gtm_verno` ) then
 endif
 
 source $gtm_tst/com/findsprgdefilename.csh	# sets the var "sprgdeoutdir" and "sprgdefile" accordingly
+
+if (! -e $sprgdeoutdir) then
+	mkdir -p $sprgdeoutdir
+	if ($status) then
+		# Directory does not exist but we are not able to create it. Exit.
+		exit 0
+	endif
+endif
 
 # If there is no write permission in the target directory, exit
 # (can happen with non-gtmtest user running T990 with gtm_test_spanreg=2/3)

--- a/com/gensprgde.csh
+++ b/com/gensprgde.csh
@@ -21,9 +21,6 @@
 
 # Attempt to generate .sprgde files.
 
-set echo
-set verbose
-
 if (! ((2 == $gtm_test_spanreg) || (3 == $gtm_test_spanreg)) || ("GT.CM" == $test_gtm_gtcm)) then
 	exit 0	# test did not want .sprgde files to be generated
 endif


### PR DESCRIPTION
The generated .sprgde files can later be used in a test run with -env gtm_test_spanreg=1
and that would help exercise spanning regions codepath.