### PR TITLE
Allow for wider range of <max node len> due to enhanced testing of random sprgde files in E_ALL

### DIFF
--- a/collation/outref/def_to_pol.txt
+++ b/collation/outref/def_to_pol.txt
@@ -56,12 +56,12 @@ ver PASS
 
 GTM>
 ##SOURCE_PATH##/mupip extract extr.bin -format=bin
-##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
+##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
+##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
 ##TEST_AWK%GTM-I-RECORDSTAT, .CGLOBALVAR1:	  Key cnt: 502  max subsc len: 18  max rec len: 14  max node len: 3.
 ##TEST_AWK%GTM-I-RECORDSTAT, .morefill:	  Key cnt: 20  max subsc len: 38  max rec len: 5  max node len: 4.
 %GTM-I-RECORDSTAT, ^prefix:	  Key cnt: 1  max subsc len: 8  max rec len: 1  max node len: 13
-##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7[567]
+##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7.
 Files Created in ##TEST_PATH##:
 Using: ##SOURCE_PATH##/mumps -run GDE
 mumps.gld

--- a/collation/outref/pol_to_def.txt
+++ b/collation/outref/pol_to_def.txt
@@ -49,12 +49,12 @@ ver PASS
 
 GTM>
 ##SOURCE_PATH##/mupip extract extr.bin -format=bin
-##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
+##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
+##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
 ##TEST_AWK%GTM-I-RECORDSTAT, .CGLOBALVAR1:	  Key cnt: 502  max subsc len: 18  max rec len: 14  max node len: 3.
 ##TEST_AWK%GTM-I-RECORDSTAT, .morefill:	  Key cnt: 20  max subsc len: 38  max rec len: 5  max node len: 4.
 %GTM-I-RECORDSTAT, ^prefix:	  Key cnt: 1  max subsc len: 8  max rec len: 1  max node len: 13
-##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7[567]
+##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7.
 Files Created in ##TEST_PATH##:
 Using: ##SOURCE_PATH##/mumps -run GDE
 mumps.gld

--- a/collation/outref/pol_to_pol.txt
+++ b/collation/outref/pol_to_pol.txt
@@ -49,12 +49,12 @@ ver PASS
 
 GTM>
 ##SOURCE_PATH##/mupip extract extr.bin -format=bin
-##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .CGLOBALVAR1:	  Key cnt: 502  max subsc len: 18  max rec len: 14  max node len: 3[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .morefill:	  Key cnt: 20  max subsc len: 38  max rec len: 5  max node len: 4[567]
+##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
+##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
+##TEST_AWK%GTM-I-RECORDSTAT, .CGLOBALVAR1:	  Key cnt: 502  max subsc len: 18  max rec len: 14  max node len: 3.
+##TEST_AWK%GTM-I-RECORDSTAT, .morefill:	  Key cnt: 20  max subsc len: 38  max rec len: 5  max node len: 4.
 %GTM-I-RECORDSTAT, ^prefix:	  Key cnt: 1  max subsc len: 8  max rec len: 1  max node len: 13
-##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7[567]
+##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7.
 Files Created in ##TEST_PATH##:
 Using: ##SOURCE_PATH##/mumps -run GDE
 mumps.gld

--- a/collation/outref/pol_to_revpol.txt
+++ b/collation/outref/pol_to_revpol.txt
@@ -49,12 +49,12 @@ ver PASS
 
 GTM>
 ##SOURCE_PATH##/mupip extract extr.bin -format=bin
-##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .CGLOBALVAR1:	  Key cnt: 502  max subsc len: 18  max rec len: 14  max node len: 3[567]
-##TEST_AWK%GTM-I-RECORDSTAT, .morefill:	  Key cnt: 20  max subsc len: 38  max rec len: 5  max node len: 4[567]
+##TEST_AWK%GTM-I-RECORDSTAT, .AGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
+##TEST_AWK%GTM-I-RECORDSTAT, .BGLOBALVAR1:	  Key cnt: 15622  max subsc len: 57  max rec len: 15  max node len: 7.
+##TEST_AWK%GTM-I-RECORDSTAT, .CGLOBALVAR1:	  Key cnt: 502  max subsc len: 18  max rec len: 14  max node len: 3.
+##TEST_AWK%GTM-I-RECORDSTAT, .morefill:	  Key cnt: 20  max subsc len: 38  max rec len: 5  max node len: 4.
 %GTM-I-RECORDSTAT, ^prefix:	  Key cnt: 1  max subsc len: 8  max rec len: 1  max node len: 13
-##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7[567]
+##TEST_AWK%GTM-I-RECORDSTAT, TOTAL:	  Key cnt: 31767  max subsc len: 57  max rec len: 15  max node len: 7.
 Files Created in ##TEST_PATH##:
 Using: ##SOURCE_PATH##/mumps -run GDE
 mumps.gld


### PR DESCRIPTION
There was a test failure in the collation/pol_to_revpol test. A max node len of 35 or
36 or 37 was accepted in the reference file but we ended up with 33. This is possible
because max node len in turn translates to the maximum record size (the maximum of the
"rsiz" field in the record header of the many records a GDS block has) and this rsiz
field can change because of a different distribution of the same set of nodes across
the available regions (due to the sprgde file mapping randomization, a recent test
change to generate .sprgde files randomly).

All reference files that already had a small allowance have now been fixed to widen the
range of allowed values. In the specific failure case, 3[567] was changed to 3. in the
reference file i.e. any of the values 30, 31, 32, ... , 39 are now considered acceptable.