### PR TITLE
Fix various issues causing sporadic 64bittn/rolling_upgrade test failures

### DIFF
--- a/64bittn/u_inref/shut_normal_kill.csh
+++ b/64bittn/u_inref/shut_normal_kill.csh
@@ -4,7 +4,7 @@
 # Copyright (c) 2006-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -31,25 +31,7 @@ if ( 0 == $rolling_upgrade_shut_kill ) then
 		exit 1
 	endif
 	# mupip journal rollback should be done to make the crashed instance usable.
-	# But it should be done using the old version and not the current version.
-	# Make sure journal rollback does NOT work if attempted with the current version (will fail with GTM-E-VERMISMATCH)
-	$gtm_tst/com/backup_dbjnl.csh crashed_${msver} '*.gld *.dat *.repl' 'cp' 'nozip'
-	\rm $gtm_repl_instance # recreated below
-
-	source $gtm_tst/com/switch_gtm_version.csh $tst_ver $tst_image
-	$MUPIP replic -instance_create -name=$gtm_test_cur_sec_name $gtm_test_qdbrundown_parms
-	$GDE exit >>&! gde_${tst_ver}.out
-	# Below backward rollback invocation is expected to fail. Therefore pass "-backward" explicitly to mupip_rollback.csh
-	# (and avoid implicit "-forward" rollback invocation that would otherwise happen by default).
-	$gtm_tst/com/mupip_rollback.csh -backward -fetchresync=$portno -losttrans=RCVR_SHUT_oldver.lost "*" >&! rollback_sideB_${tst_ver}.outx
-	if !($status) then
-		echo "TEST-E-FAIL mupip journal rollback using current version is expected to fail with GTM-E-VERMISMATCH, but succeeded"
-		exit 1
-	endif
-
-	# Now attempt journal rollback using oldver. It should work
-	$sv_oldver
-	cp -p crashed_${msver}/* .
+	# Note: The rollback is done using the old version and not the current version.
 	$gtm_tst/com/mupip_rollback.csh -verbose -fetchresync=$portno -losttrans=RCVR_SHUT_oldver.lost "*" >&! rollback_sideB_pass.out
 	if !($status) then
 		echo "PASS"
@@ -59,11 +41,6 @@ if ( 0 == $rolling_upgrade_shut_kill ) then
 	endif
 	mkdir save_after_rollbck
 	cp mumps.gld mumps.repl *.dat *.mjl* save_after_rollbck/
-	# if version is prior to V6.0-002 rundown is necessary (GTM-7698)
-	if (`expr "$msver" "<" "V60002"`) then
-		$gtm_tst/com/backup_dbjnl.csh after_rollback_${msver} '*.gld *.dat *.repl' 'cp'
-		$MUPIP rundown -region "*" >&! rundown_sideB.outx
-	endif
 else
 	$gtm_tst/com/RCVR_SHUT.csh "." >&! SHUT_${shut_time}.out
 	if !($status) then

--- a/com/random_ver.csh
+++ b/com/random_ver.csh
@@ -4,7 +4,7 @@
 # Copyright (c) 2013-2015 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #                                                               #
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -154,10 +154,11 @@ if ($?vertype) then
 		set islt    = "<"
 	breaksw
 	case "ms":
-		set minimum = "V51000" # V51000 is the first multisite version.
+		set minimum = "V54001"	# V51000 is the first multisite version, but we have 64-bit build only from V54001
+					# hence this minimum choice.
 		set isgt    = ">="
 		set maximum = "$tst_ver" # A version before the current version
-		set islt    = "<="
+		set islt    = "<"
 	breaksw
 	case "any":
 		set minimum = "V44002" # V44002 is the min supported version after triggers


### PR DESCRIPTION
1) com/random_ver.csh : The 64bittn/rolling_upgrade reference file has usages of
   ##PRIORVER## in it. This means we have to ensure the randomly chosen prior version
   cannot be the same as the current version being tested. Therefore change the <ms>
   type invocation of random_ver.csh to always choose a random version < $tst_ver
   (i.e. set islt to < instead of <=).

2) com/random_ver.csh : Fix minimum version for <ms> type to be V54001 since that
   is oldest 64-bit build we have. Otherwise, using a 32-bit build (in case V53002,
   which is > V51000 the previous minimum, gets randomly chosen) would result in the
   following error in imptp.out
      %GTM-E-INVOBJ, Cannot ZLINK object file due to unexpected format
      %GTM-I-TEXT, bad magic

3) 64bittn/u_inref/shut_normal_kill.csh : This script used to leave ipcs around after
   a crash using the NO_IPCRM parameter in the receiver_crash.csh call. But that
   was removed in a previous commit due to a possible test hang (due to DBDANGER
   and instance freeze). This meant we will no longer have a database shared memory
   section of a different version lying around so the portion of the test that was
   expecting a VERMISMATCH was no longer correct. Remove that code since we no longer
   use NO_IPCRM. Similarly, remove a MUPIP RUNDOWN usage that is no longer needed.