### PR TITLE
Fix 64bittn/rolling_upgrade test failure with TLSCONVSOCK error in source server

### DIFF
--- a/com/set_active_version.csh
+++ b/com/set_active_version.csh
@@ -65,6 +65,7 @@ if ($ydbenv) then
 		exit -1
 	endif
 	setenv gtm_dist $gtm_root/$verno/$image
+	setenv ydb_dist $gtm_root/$verno/$image	# needed at least by maskpass (e.g. set_tls_env.csh invocation for a different version)
 	setenv gtm_exe $gtm_dist
 	if ($?gtm_chset) then
 		if ("$gtm_chset" != "UTF-8") then


### PR DESCRIPTION
Set ydb_dist env var in set_active_version.csh as it is needed by maskpass.
The set_active_version.csh script switches the YottaDB version currently in use.
It had set gtm_dist but as part of r1.20, ydb_dist variable was introduced.
This script needs to also set ydb_dist env var. Not doing so can later cause
utilities like "maskpass" (which now rely on the value of "ydb_dist" instead of
"gtm_dist") to not perform correctly.

The 64bittn/rolling_upgrade subtest failed when R120 was chosen as the
random prior version with the following error in the source server.

%GTM-W-TLSCONVSOCK, Failed to convert Unix TCP/IP socket to TLS/SSL aware socket
%GTM-I-TEXT, Failed to read private key T998/com/tls/certs/INSTANCE1.key.
	Reason: error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt

That is because gtmtls_passwd_<instname> (e.g. gtmtls_passwd_INSTANCE1) was set based
on what "maskpass" returned and that was operating with ydb_dist set to the current
version instead of the chosen prior version (R120) and so the R120 source server
was using an out-of-sync gtmtls_passwd_<instname> env var. Now that ydb_dist is
properly set whenever the test switches versions, "maskpass" returns correct values
and gtmtls_passwd_<instname> gets set to the correct version.