### PR TITLE
Fix two issues in v63004/gtm8860 subtest in prior commit

### DIFF
--- a/v63004/inref/README.txt
+++ b/v63004/inref/README.txt
@@ -1,0 +1,3 @@
+This is a dummy file that is needed in "inref" directory of every new test (until we have at least one
+other file in this directory) to avoid test failures due to ZROSYNTAX errors because the test framework
+always assumes $gtm_tst/$tst/inref exists when it sets up ydb_routines/gtmroutines env var for the test.

--- a/v63004/outref/outref.txt
+++ b/v63004/outref/outref.txt
@@ -1,3 +1,5 @@
 v63004 test starts...
+##SUSPEND_OUTPUT REPLIC
 PASS from gtm8860
+##ALLOW_OUTPUT REPLIC
 v63004 test DONE.


### PR DESCRIPTION
1) The reference file needs to be adjusted for the -replic test run.
2) inref directory needs an empty file to avoid ZROSYNTAX errors.