### PR TITLE
Changed gtm8791.exp ...

### DIFF
--- a/v63004/u_inref/gtm8791.exp
+++ b/v63004/u_inref/gtm8791.exp
@@ -13,20 +13,26 @@
 set timeout 60
 spawn /usr/local/bin/tcsh -f
 
+expect_after {
+	timeout { timeout_procedure }
+}
+
+proc timeout_procedure { } {
+	puts "timeout occurred"
+	exit -1
+}
+
+
 send -- "\$gtm_dist/lke\r"
 
-expect -exact "LKE>"
 # Send <Ctrl-Z>
-send -- "\x1A\r"
+expect -exact "LKE>" {send -- "\x1A\r"}
 
-expect -exact "Suspended (signal)"
-send -- "fg\r"
+expect -exact "Suspended (signal)" {expect ">" {send -- "fg\r"}}
 
 #exits from the LKE prompt
-expect -exact "LKE>"
-send -- "exit\r"
+expect -exact "LKE>" {send -- "exit\r"}
 
 #exits from the tcsh shell
-expect -exact ">"
-send -- "exit\r"
+expect -exact ">" {send -- "exit\r"}
 

--- a/v63004/u_inref/gtm8791.exp
+++ b/v63004/u_inref/gtm8791.exp
@@ -26,13 +26,18 @@ proc timeout_procedure { } {
 send -- "\$gtm_dist/lke\r"
 
 # Send <Ctrl-Z>
-expect -exact "LKE>" {send -- "\x1A\r"}
+expect -exact "LKE>"
+send -- "\x1A\r"
 
-expect -exact "Suspended (signal)" {expect ">" {send -- "fg\r"}}
+expect -exact "Suspended (signal)"
+expect ">"
+send -- "fg\r"
 
 #exits from the LKE prompt
-expect -exact "LKE>" {send -- "exit\r"}
+expect -exact "LKE>"
+send -- "exit\r"
 
 #exits from the tcsh shell
-expect -exact ">" {send -- "exit\r"}
+expect -exact ">"
+send -- "exit\r"
 


### PR DESCRIPTION
In order to push a timeout message and exit upon a timed out expect statement. The syntax of the send statement has also been changed so that a send statement will only be executed upon a successful expect statement. 