### PR TITLE
[#218] Test for new ydb_app_ensures_isolation env var (YottaDB/YottaDB#218)

### DIFF
--- a/com/imptp.m
+++ b/com/imptp.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2004-2016 Fidelity National Information		;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -455,7 +458,10 @@ noop;
 	write "TEST-I-INFO : did noop",!
 	quit
 tpnoiso;
-	view "NOISOLATION":"^arandom,^brandomv,^crandomva,^drandomvariable,^erandomvariableimptp,^frandomvariableinimptp,^grandomvariableinimptpfill,^hrandomvariableinimptpfilling,^irandomvariableinimptpfillprgrm,^jrandomvariableinimptpfillprogram"
+	if (""=$ztrnlnm("ydb_app_ensures_isolation")) do
+	. view "NOISOLATION":"^arandom,^brandomv,^crandomva,^drandomvariable,^erandomvariableimptp,^frandomvariableinimptp,^grandomvariableinimptpfill,^hrandomvariableinimptpfilling,^irandomvariableinimptpfillprgrm,^jrandomvariableinimptpfillprogram"
+	; else imptp.csh has already set the env var to the above list of globals
+	;
 	write "$view(""NOISOLATION"",""^arandom"")=",$view("NOISOLATION","^arandom"),!
 	write "$view(""NOISOLATION"",""^brandomv"")=",$view("NOISOLATION","^brandomv"),!
 	write "$view(""NOISOLATION"",""^crandomva"")=",$view("NOISOLATION","^crandomva"),!

--- a/com/imptpxc.m
+++ b/com/imptpxc.m
@@ -25,17 +25,7 @@ imptpdztrig;
 	quit
 
 tpnoiso;
-	view "NOISOLATION":"^arandom,^brandomv,^crandomva,^drandomvariable,^erandomvariableimptp,^frandomvariableinimptp,^grandomvariableinimptpfill,^hrandomvariableinimptpfilling,^irandomvariableinimptpfillprgrm,^jrandomvariableinimptpfillprogram"
-	write "$view(""NOISOLATION"",""^arandom"")=",$view("NOISOLATION","^arandom"),!
-	write "$view(""NOISOLATION"",""^brandomv"")=",$view("NOISOLATION","^brandomv"),!
-	write "$view(""NOISOLATION"",""^crandomva"")=",$view("NOISOLATION","^crandomva"),!
-	write "$view(""NOISOLATION"",""^drandomvariable"")=",$view("NOISOLATION","^drandomvariable"),!
-	write "$view(""NOISOLATION"",""^erandomvariableimptp"")=",$view("NOISOLATION","^erandomvariableimptp"),!
-	write "$view(""NOISOLATION"",""^frandomvariableinimptp"")=",$view("NOISOLATION","^frandomvariableinimptp"),!
-	write "$view(""NOISOLATION"",""^grandomvariableinimptpfill"")=",$view("NOISOLATION","^grandomvariableinimptpfill"),!
-	write "$view(""NOISOLATION"",""^hrandomvariableinimptpfilling"")=",$view("NOISOLATION","^hrandomvariableinimptpfilling"),!
-	write "$view(""NOISOLATION"",""^irandomvariableinimptpfillprgrm"")=",$view("NOISOLATION","^irandomvariableinimptpfillprgrm"),!
-	write "$view(""NOISOLATION"",""^jrandomvariableinimptpfillprogram"")=",$view("NOISOLATION","^jrandomvariableinimptpfillprogram"),!
+	do tpnoiso^imptp
 	quit
 
 helper1	;

--- a/com/tpntpupd.m
+++ b/com/tpntpupd.m
@@ -1,6 +1,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;								;
-;	Copyright 2003, 2013 Fidelity Information Services, Inc	;
+; Copyright 2003, 2013 Fidelity Information Services, Inc	;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
 ;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
@@ -32,9 +35,11 @@ tpntpupd;
 	; there is a huge list of non-existent globals that are specified. This is specifically present to test that
 	; process_gvt_pending_list() processes the linked list of pending gvts correctly as each region gets opened.
 	;
-	VIEW "NOISOLATION":"+^aa,^aaa,^aaaa,^bb,^bbb,^bbbb,^cc,^ccc,^cccc,^dd,^ddd,^dddd"
-	VIEW "NOISOLATION":"+^ee,^eee,^eeee,^ff,^fff,^ffff,^gg,^ggg,^gggg,^hh,^hhh,^hhhh"
-	VIEW "NOISOLATION":"+^ii,^iii,^iiii"
+	if (""=$ztrnlnm("ydb_app_ensures_isolation")) do
+	. VIEW "NOISOLATION":"+^aa,^aaa,^aaaa,^bb,^bbb,^bbbb,^cc,^ccc,^cccc,^dd,^ddd,^dddd"
+	. VIEW "NOISOLATION":"+^ee,^eee,^eeee,^ff,^fff,^ffff,^gg,^ggg,^gggg,^hh,^hhh,^hhhh"
+	. VIEW "NOISOLATION":"+^ii,^iii,^iiii"
+	; else dse_cache.csh has already set the env var to the above list of globals
 	;
 	if $data(^secgldno)  do
 	.	set secgldno=^secgldno

--- a/com/tpntpupd_set_noisolation.csh
+++ b/com/tpntpupd_set_noisolation.csh
@@ -1,0 +1,28 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+
+# Randomly set ydb_app_ensures_isolation env var to list of globals that need VIEW "NOISOLATION" set.
+# If not set, tpntpupd.m (invoked later from caller script) will do the needed VIEW "NOISOLATION" call.
+if (! $?gtm_test_replay) then
+	@ rand = `$gtm_exe/mumps -run rand 2`
+	# If rand = 0 -> set env var here
+	if (0 == $rand) then
+		set noisolist = "^aa,^aaa,^aaaa,^bb,^bbb,^bbbb,^cc,^ccc,^cccc,^dd,^ddd,^dddd"
+		set noisolist = "$noisolist,^ee,^eee,^eeee,^ff,^fff,^ffff,^gg,^ggg,^gggg,^hh,^hhh,^hhhh"
+		set noisolist = "$noisolist,^ii,^iii,^iiii"
+		setenv ydb_app_ensures_isolation "$noisolist"
+		echo "setenv ydb_app_ensures_isolation $noisolist"	>> settings.csh
+	endif
+	# If rand = 1 (i.e. ydb_app_ensures_isolation env var is not set) -> do VIEW "NOISOLATION" command later
+endif
+

--- a/dse/u_inref/dse_cache.csh
+++ b/dse/u_inref/dse_cache.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2003, 2015 Fidelity National Information	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -19,6 +22,10 @@ $gtm_tst/com/dbcreate.csh mumps 8 -rec=8000
 foreach no (0 1 2 3 4 5 6 7)
 	cp mumps.gld mumpssec$no.gld
 end
+
+# Randomly set ydb_app_ensures_isolation env var to list of globals that need VIEW "NOISOLATION" set.
+# If not set, tpntpupd.m (invoked later from dsecache.m below) will do the needed VIEW "NOISOLATION" call.
+source $gtm_tst/com/tpntpupd_set_noisolation.csh
 
 $GTM <<GTM_EOF
 set ^secgldnm="mumpssec"	; will randomly pick one or the other global directory

--- a/v53002/u_inref/C9E04002596.csh
+++ b/v53002/u_inref/C9E04002596.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh
 #################################################################
 #								#
-#	Copyright 2008, 2013 Fidelity Information Services, Inc	#
+# Copyright 2008, 2013 Fidelity Information Services, Inc	#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -18,6 +21,10 @@ $gtm_tst/com/dbcreate.csh mumps 8 -rec=8000
 foreach no (0 1 2 3 4 5 6 7)
 	cp mumps.gld mumpssec$no.gld
 end
+
+# Randomly set ydb_app_ensures_isolation env var to list of globals that need VIEW "NOISOLATION" set.
+# If not set, tpntpupd.m (invoked later from c002596.m below) will do the needed VIEW "NOISOLATION" call.
+source $gtm_tst/com/tpntpupd_set_noisolation.csh
 
 $GTM <<GTM_EOF
 	do ^c002596


### PR DESCRIPTION
Two test framework scripts that were already VIEW "NOISOLATION" were identified.

1) imptp.m
2) tpntpupd.m

And they were enhanced to check for the new env var and if present use that
and if not do VIEW "NOISOLATION" commands like they previously did.

This way all tests that use imptp.m (many dozens) and tpntpupd.m (2 tests) will
automatically test the new env var.

Took this opportunity to do some "usesimpleapi"-related cleanup in imptp.csh.