### PR TITLE
[#215] Fix expect/contjnlbufwriter subtest (due to code changes in YottaDB/YottaDB#215)

### DIFF
--- a/expect/u_inref/gtm4661c.exp
+++ b/expect/u_inref/gtm4661c.exp
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -21,9 +24,9 @@ expect ">"
 send -- "set prompt=\"termmumps > \"\r"
 # Expect the clean prompt
 expect "termmumps >"
-# SET, HANG and SET along with WHITE-BOX code change and EPOCH interval of 1 seconds ensures that
+# SET, followed by a VIEW "JNLWAIT" along with WHITE-BOX code change and EPOCH interval of 1 seconds ensures that
 # process gets suspended while holding the lock on JOURNAL buffer.
-send -- "\$gtm_exe/mumps -run %XCMD 'write \"proc1=\"_\$j,! set ^a=1 hang 1 set ^a=2'\r"
+send -- "\$gtm_exe/mumps -run %XCMD 'write \"proc1=\"_\$j,! set ^a=1 view \"jnlwait\"'\r"
 expect "proc1=*\r"
 expect {
 	"*Suspended (signal)\r" {puts "Suspended (signal)"}


### PR DESCRIPTION
The test was doing a SET ^a=1 followed by a HANG 1 and another SET ^a=2 in order
to reach jnl_sub_qio_start() while we were not holding crit lock so we would suspend
ourselves (due to the white-box test case) and cause another process to issue a
JNLPROCSTUCK message.

jnl_sub_qio_start() was invoked a lot of times in the above sequence of commands
and the first invocation itself resulted in a call to suspsigs_handler() to suspend
but it did not suspend because we were holding crit. The invocation that caused the
process to suspend was a little later when jnl_sub_qio_start() was invoked through
t_end() -> wcs_timer_start() -> jnl_qio_start() -> jnl_sub_qio_start(). But before
t_end() invokes wcs_timer_start(), it does a REVERT which now causes a check of
whether suspend() was deferred (due to #215 code changes) and so we suspend the
process right there (because at this point, we have released crit and are out
of the phase2 commit logic). And so the process does not ever reach wcs_timer_start()
and never gets suspended while holding the jnl buffer qio lock like the test expects
causing the test to eventually fail (because no JNLPROCSTUCK message is later seen).

To work around this, the sequence of commands done by the test have now been simplified
to a SET ^a=1 followed by a VIEW "JNLWAIT". The latter invokes jnl_wait() which call
jnl_sub_qio_start() while we do not hold crit and so the process suspends right there
recreating the same situation that the test wants for a later JNLPROCSTUCK message.