### PR TITLE
Fix timing issue in suppl_inst_C/gtm8074 subtest

### DIFF
--- a/suppl_inst_C/outref/gtm8074.txt
+++ b/suppl_inst_C/outref/gtm8074.txt
@@ -39,6 +39,8 @@ Starting Passive Source Server and Receiver Server in ##FILTERED##_REMOTE_TEST_P
 ==Executing MULTISITE_REPLIC 'SYNC INST1 INST3'==
 # Shut receiver side of A->P connection
 ==Executing MULTISITE_REPLIC 'STOPRCV INST1 INST3'==
+# Wait for ZERO backlog on P->Q side
+==Executing MULTISITE_REPLIC 'SYNC INST3 INST4'==
 # Shut source side of P->Q connection
 ==Executing MULTISITE_REPLIC 'STOPSRC INST3 INST4'==
 # Break previous journal link on P before ROLLBACK

--- a/suppl_inst_C/u_inref/gtm8074.csh
+++ b/suppl_inst_C/u_inref/gtm8074.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2014-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -42,6 +45,9 @@ $MSR SYNC INST1 INST3
 
 echo "# Shut receiver side of A->P connection"
 $MSR STOPRCV INST1 INST3
+
+echo "# Wait for ZERO backlog on P->Q side"
+$MSR SYNC INST3 INST4
 
 echo "# Shut source side of P->Q connection"
 $MSR STOPSRC INST3 INST4


### PR DESCRIPTION
It is possible, in rare cases, when we shut down the P->Q source server that P
is ahead of Q (i.e. all of the updates on P have not yet been replicated to Q).
In that case, since the later parts of the test do not do anything with Q, the
dbcheck at the end of the test will notice Q as lagging P and in turn lagging A.
This commit fixes that issue by waiting for P->Q to be in sync before shutting
down the corresponding source server.