### PR TITLE
Fix v60001/tprestart subtest failures due to lack of bitmap restarts (code: a)

### DIFF
--- a/v60001/u_inref/tprestart.csh
+++ b/v60001/u_inref/tprestart.csh
@@ -15,7 +15,9 @@
 #################################################################
 
 setenv echoline "------------------------------------------------------------------"
-$gtm_tst/com/dbcreate.csh mumps 1 -allocation=2048 -extension_count=2048
+# Set global buffers to a high value (8Ki) to avoid G type of restarts (which are otherwise the most common restarts
+# with global buffers set to the default of 1Ki). Also set allocation and extension to 8Ki to reduce frequency of DBFILEXT messages.
+$gtm_tst/com/dbcreate.csh mumps 1 -allocation=8192 -extension_count=8192 -global_buffer_count=8192
 
 echo $echoline
 echo "i) gtm_tprestart_log_first and gtm_tprestart_log_delta are not defined."


### PR DESCRIPTION
In one test run, the last stage of this subtest did not encounter even one bitmap
related restart (code 'a'). In the syslog, a lot of G type restarts were seen
which are indicative of lack of global buffers. So the test is enhanced to have
8 times the default # of global buffers (from 1Ki to 8Ki). That should almost
eliminate the likelihood of G type restarts and increase the likelihood of 'a'
type restarts which this test expects.

While at that, also increased the allocation and extension settings 4 times
from 2Ki to 8Ki to reduce the frequency of DBFILEXT syslog messages. This way
the syslog will most likely have just the 'a' type restarts this test cares about.