### PR TITLE
Fix 64bittn/rolling_upgrade subtest failure due to lack of REPLINSTNOHIST error in rare cases

### DIFF
--- a/com/sync_to_disk.csh
+++ b/com/sync_to_disk.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2006, 2013 Fidelity Information Services, Inc	#
+# Copyright 2006, 2013 Fidelity Information Services, Inc	#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -10,4 +13,7 @@
 #								#
 #################################################################
 
-$gtm_exe/mumps -run %XCMD 'view "EPOCH"'
+# Use VIEW "FLUSH" (and not VIEW "EPOCH") since the former is supported by older versions too
+# and this script could be invoked by tests that use older versions.
+
+$gtm_exe/mumps -run %XCMD 'view "FLUSH"'


### PR DESCRIPTION
In in-house testing, a test failure was seen with the following symptom.

> TEST-E-NOTFOUND message Receiver server exiting not found in RCVR_18_44_51_REPLINSTNOHIST.log after 120 secs
> Waited from: Sat May 5 18:44:53 EDT 2018
>          to: Sat May 5 18:46:54 EDT 2018

But the real issue was that a REPLINSTNOHIST error was expected in the receiver server
but not found.

The cause of this was that after B was crashed and a rollback done, the post-rollback
seqno of B was 1 and so later when a receiver was started on B with the test version
and A was running with the older version, the source server on A did not need to
verify any history (if it had to verify history, the receiver would have returned no
history record because the replication instance file on B was re-created in this case
and that would have caused A's source server to exit with a REPLINSTNOHIST error in
turn causing the receiver server to terminate). And because of this, the receiver on
B ran fine without terminating and failed the test.

The fix is to ensure that on B, after a crash, the database has at least a non-zero
csd->reg_seqno in its database file header since this is what is finally used by the
fetchresync rollback to derive the resync_seqno (in line 12 of rollback_sideB_pass.out
above) to send across to the source server on A.

While at this, the framework script com/sync_to_disk.csh was enhanced to use VIEW "FLUSH"
instead of VIEW "EPOCH since older versions like V54001 support the former but not the
latter and they are equivalent in newer versions. This lets us use sync_to_disk.csh in
this particular test.