### PR TITLE
Fix test failures with rare failure symptom <TEST-E-PORTNO : Invalid port number>

### DIFF
--- a/com/portno_acquire.csh
+++ b/com/portno_acquire.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2011-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -73,7 +76,7 @@ while ( ($nstat == 0) && ($portno < $port_upperlimit ) )
 		# so there is a good chance of a port being shown as unused incorrectly. Hence introduce the below check
 		# Regarding $head bypass : most scripts which use MSR.. expect to just keep going in most cases even if there is
 		# an error, so we can't use $head which can fail.
-		head -n 1 $port_reservation_file | $grep "^$$ $tst_working_dir" > /dev/null	# BYPASSOK $head
+		head -n 1 $port_reservation_file |& $grep "^$$ $tst_working_dir" > /dev/null	# BYPASSOK $head
 		if !($status) then
 			rm $port_reservation_file
 		else
@@ -82,7 +85,7 @@ while ( ($nstat == 0) && ($portno < $port_upperlimit ) )
 		echo `date` "# $portno is in use..." >> $logfile
 	else
 		# unused port, check if it was me who grabbed the reservation file
-		head -n 1 $port_reservation_file | $grep "^$$ $tst_working_dir" > /dev/null	# BYPASSOK $head
+		head -n 1 $port_reservation_file |& $grep "^$$ $tst_working_dir" > /dev/null	# BYPASSOK $head
 		if ($status) then
 			#oops, it was someone else who got it first
 			set nstat = 0


### PR DESCRIPTION
There was an in-house test failure with the below failure symptom
	TEST-E-PORTNO : Invalid port number : head: cannot open '/tmp/test_36322.txt'
		for reading: No such file or directory 3607

In this case, the "head" command on a port reservation file resulted in an error because
the reservation file was concurrently deleted (by some other test that was in the
process of releasing that port number) and the error text from "head" (which was of
the form "cannot open ... for reading") got placed in the final portno choice of 36507.
So instead of portno returned from portno_acquire.csh being just "36507" it ended up being
"head: cannot open '/tmp/test_36322.txt' for reading: No such file or directory 36507".

The fix is to redirect the stderr (in addition to stdout) of the "head" command into
the pipeline that is being fed to the "grep" command, i.e. | changed to a |&