### PR TITLE
New v63004/gtm8874 subtest (tests GTM-8874 in V63004

### DIFF
--- a/v63004/inref/gtm8874.m
+++ b/v63004/inref/gtm8874.m
@@ -1,0 +1,73 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+gtm8874()
+
+	WRITE "STATSHARE DEFAULT: "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!
+	WRITE "STATSHARE AREG:    "
+	WRITE $VIEW("STATSHARE","AREG"),!
+	WRITE "STATSHARE BREG:    "
+	WRITE $VIEW("STATSHARE","BREG"),!
+	WRITE !
+
+	WRITE "VIEW ""STATSHARE"":""AREG"""
+	VIEW "STATSHARE":"AREG"
+	WRITE !
+
+	WRITE "STATSHARE DEFAULT: "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!
+	WRITE "STATSHARE AREG:    "
+	WRITE $VIEW("STATSHARE","AREG"),!
+	WRITE "STATSHARE BREG:    "
+	WRITE $VIEW("STATSHARE","BREG"),!
+	WRITE !
+
+	WRITE "VIEW ""STATSHARE"":""DEFAULT""",!
+	VIEW "STATSHARE":"DEFAULT"
+	WRITE "VIEW ""NOTSTATSHARE"":""AREG""",!
+	VIEW "NOSTATSHARE":"AREG"
+	WRITE !
+
+	WRITE "STATSHARE DEFAULT: "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!
+	WRITE "STATSHARE AREG:    "
+	WRITE $VIEW("STATSHARE","AREG"),!
+	WRITE "STATSHARE BREG:    "
+	WRITE $VIEW("STATSHARE","BREG"),!
+	WRITE !
+
+	WRITE "VIEW ""STATSHARE"""
+	VIEW "STATSHARE"
+	WRITE !
+
+	WRITE "STATSHARE DEFAULT: "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!
+	WRITE "STATSHARE AREG:    "
+	WRITE $VIEW("STATSHARE","AREG"),!
+	WRITE "STATSHARE BREG:    "
+	WRITE $VIEW("STATSHARE","BREG"),!
+	WRITE !
+
+	WRITE "VIEW ""NOSTATSHARE"""
+	VIEW "NOSTATSHARE"
+	WRITE !
+
+	WRITE "STATSHARE DEFAULT: "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!
+	WRITE "STATSHARE AREG:    "
+	WRITE $VIEW("STATSHARE","AREG"),!
+	WRITE "STATSHARE BREG:    "
+	WRITE $VIEW("STATSHARE","BREG"),!
+	WRITE !
+
+	quit

--- a/v63004/inref/gtm8874.m
+++ b/v63004/inref/gtm8874.m
@@ -10,7 +10,14 @@
 ;								;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
-gtm8874()
+testA
+	WRITE "Check for open region files:",!
+	ZSYSTEM "ls -l /proc/"_$job_"/fd | $grep '.dat$' | awk -F '/' '{print $(NF)}' "
+	WRITE !,"VIEW ""STATSHARE"" ",!
+	VIEW "STATSHARE"
+	WRITE "Check for open region files:",!
+	ZSYSTEM "ls -l /proc/"_$job_"/fd | $grep '.dat$' | awk -F '/' '{print $(NF)}' "
+	WRITE !
 
 	WRITE "STATSHARE DEFAULT: "
 	WRITE $VIEW("STATSHARE","DEFAULT"),!
@@ -36,7 +43,6 @@ gtm8874()
 	VIEW "STATSHARE":"DEFAULT"
 	WRITE "VIEW ""NOTSTATSHARE"":""AREG""",!
 	VIEW "NOSTATSHARE":"AREG"
-	WRITE !
 
 	WRITE "STATSHARE DEFAULT: "
 	WRITE $VIEW("STATSHARE","DEFAULT"),!
@@ -69,5 +75,38 @@ gtm8874()
 	WRITE "STATSHARE BREG:    "
 	WRITE $VIEW("STATSHARE","BREG"),!
 	WRITE !
+
+	quit
+
+
+
+testB
+	;WRITE "VIEW ""NOSTATSHARE"""
+	;VIEW "NOSTATSHARE"
+	;WRITE !
+
+	WRITE "STATSHARE DEFAULT: "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!
+	WRITE "STATSHARE AREG:    "
+	WRITE $VIEW("STATSHARE","AREG"),!
+	WRITE "STATSHARE BREG:    "
+	WRITE $VIEW("STATSHARE","BREG"),!
+	WRITE !
+
+	quit
+
+
+testC
+	WRITE "SET $ZGBLDIR=""otherA.gld"" ",!
+	SET $ZGBLDIR="otherA.gld"
+	WRITE "VIEW ""STATSHARE"":""DEFAULT"" ",!
+	VIEW "STATSHARE":"DEFAULT"
+	WRITE "$VIEW(""STATSHARE"",""DEFAULT""): "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!!
+
+	WRITE "SET $ZGBLDIR=""otherB.gld"" ",!
+	SET $ZGBLDIR="otherB.gld"
+	WRITE "$VIEW(""STATSHARE"",""DEFAULT""): "
+	WRITE $VIEW("STATSHARE","DEFAULT"),!
 
 	quit

--- a/v63004/instream.csh
+++ b/v63004/instream.csh
@@ -15,6 +15,7 @@
 # List of subtests of the form "subtestname [author] description"
 #-----------------------------------------------------------------------------------------------------------------
 # gtm8909	    [jake]  Tests that <ctrl-c> within the help facility no longer leads to EN0256 error upon exit
+# gtm8874	    [jake]  Tests the VIEW command's [:<region list>] qualifier
 # gtm8860	    [jake]  Tests that journal extract removes additional / from journal and output file paths
 # gtm8791	    [jake]  Tests that <ctrl-z> no longer causes segmentation violation
 # gtm8202	    [jake]  Tests the functionality of the -SEQNO qualifier for the mupip journal -extract command
@@ -26,7 +27,7 @@ echo "v63004 test starts..."
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
 setenv subtest_list_non_replic ""
-setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8860 gtm8791 gtm8202 gtm1041"
+setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8874 gtm8860 gtm8791 gtm8202 gtm1041"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/v63004/outref/gtm8874.txt
+++ b/v63004/outref/gtm8874.txt
@@ -1,0 +1,60 @@
+# Create a 3 region DB with gbl_dir mumps.gld and regions DEFAULT, AREG, and BREG
+
+# Disable sharing for BREG
+Database file ##TEST_PATH##/b.dat now has sharing of gvstats set to FALSE
+# Run testA of gtm8874.m
+Check for open region files:
+
+
+VIEW "STATSHARE" 
+Check for open region files:
+a.dat
+b.dat
+mumps.dat
+
+STATSHARE DEFAULT: 1
+STATSHARE AREG:    1
+STATSHARE BREG:    0
+
+VIEW "STATSHARE":"AREG"
+STATSHARE DEFAULT: 1
+STATSHARE AREG:    1
+STATSHARE BREG:    0
+
+VIEW "STATSHARE":"DEFAULT"
+VIEW "NOTSTATSHARE":"AREG"
+STATSHARE DEFAULT: 1
+STATSHARE AREG:    0
+STATSHARE BREG:    0
+
+VIEW "STATSHARE"
+STATSHARE DEFAULT: 1
+STATSHARE AREG:    1
+STATSHARE BREG:    0
+
+VIEW "NOSTATSHARE"
+STATSHARE DEFAULT: 0
+STATSHARE AREG:    0
+STATSHARE BREG:    0
+
+# Shut down the DB and backup necessary files to sub directory
+setenv gtm_statshare "TRUE"
+# Recreate the 3 region DB with gbl_dir mumps.gld
+# Run testB of gtm8874.m
+STATSHARE DEFAULT: 1
+STATSHARE AREG:    1
+STATSHARE BREG:    1
+
+# Shut down the DB and backup necessary files to sub directory
+unsetenv gtm_statshare
+# Create a 1 region DB with gbl_dir otherA.gld
+# Backup otherA.dat DB
+# Create a 1 region DB with gbl_dir otherB.gld
+# Move otherA.dat DB files back to current directory
+# Run testC of gtm8874.m
+SET $ZGBLDIR="otherA.gld" 
+VIEW "STATSHARE":"DEFAULT" 
+$VIEW("STATSHARE","DEFAULT"): 1
+
+SET $ZGBLDIR="otherB.gld" 
+$VIEW("STATSHARE","DEFAULT"): 0

--- a/v63004/outref/outref.txt
+++ b/v63004/outref/outref.txt
@@ -1,6 +1,7 @@
 v63004 test starts...
 ##SUSPEND_OUTPUT REPLIC
 PASS from gtm8909
+PASS from gtm8874
 PASS from gtm8860
 PASS from gtm8791
 PASS from gtm8202

--- a/v63004/u_inref/gtm8874.csh
+++ b/v63004/u_inref/gtm8874.csh
@@ -1,0 +1,24 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+
+echo "# Create a 3 region DB with region DEFAULT, AREG, and BREG"
+$gtm_tst/com/dbcreate.csh mumps 3 >>& dbcreate_log.txt
+
+#$MUPIP set -NOSTAT  -REGION region-"BREG" #>>& dbcreate_log.txt
+$MUPIP set -NOSTAT  -reg "BREG" #>>& dbcreate_log.txt
+
+echo '# Run gtm8874.m to run $VIEW and V[IEW] '
+$ydb_dist/mumps -run gtm8874
+
+$gtm_tst/com/dbcheck.csh >>& dbcreate_log.txt

--- a/v63004/u_inref/gtm8874.csh
+++ b/v63004/u_inref/gtm8874.csh
@@ -12,13 +12,47 @@
 #################################################################
 #
 
-echo "# Create a 3 region DB with region DEFAULT, AREG, and BREG"
-$gtm_tst/com/dbcreate.csh mumps 3 >>& dbcreate_log.txt
+echo "# Create a 3 region DB with gbl_dir mumps.gld and regions DEFAULT, AREG, and BREG"
+$gtm_tst/com/dbcreate.csh mumps 3 >>& dbcreate_log_1.txt
 
-#$MUPIP set -NOSTAT  -REGION region-"BREG" #>>& dbcreate_log.txt
+echo ''
+echo '# Disable sharing for BREG'
 $MUPIP set -NOSTAT  -reg "BREG" #>>& dbcreate_log.txt
 
-echo '# Run gtm8874.m to run $VIEW and V[IEW] '
-$ydb_dist/mumps -run gtm8874
+echo '# Run testA of gtm8874.m'
+$ydb_dist/mumps -run testA^gtm8874
 
-$gtm_tst/com/dbcheck.csh >>& dbcreate_log.txt
+echo '# Shut down the DB and backup necessary files to sub directory'
+$gtm_tst/com/dbcheck.csh >>& dbcreate_log_1.txt
+$gtm_tst/com/backup_dbjnl.csh dbbkup1 "*.gld *.mjl* *.mjf *.dat" cp nozip
+
+#################
+echo 'setenv gtm_statshare "TRUE"'
+setenv gtm_statshare "TRUE"
+echo '# Recreate the 3 region DB with gbl_dir mumps.gld'
+$gtm_tst/com/dbcreate.csh mumps 3 >>& dbcreate_log_2.txt
+echo '# Run testB of gtm8874.m'
+$ydb_dist/mumps -run testB^gtm8874
+
+echo '# Shut down the DB and backup necessary files to sub directory'
+$gtm_tst/com/dbcheck.csh >>& dbcreate_log_2.txt
+$gtm_tst/com/backup_dbjnl.csh dbbkup2 "*.gld *.mjl* *.mjf *.dat" cp nozip
+
+echo 'unsetenv gtm_statshare'
+unsetenv gtm_statshare
+
+##################
+echo "# Create a 1 region DB with gbl_dir otherA.gld"
+$gtm_tst/com/dbcreate.csh otherA >>& dbcreate_log_3.txt
+echo "# Backup otherA.dat DB"
+$gtm_tst/com/backup_dbjnl.csh dbbkup3 "*.gld *.mjl* *.mjf *.dat" cp nozip
+echo "# Create a 1 region DB with gbl_dir otherB.gld"
+$gtm_tst/com/dbcreate.csh otherB >>& dbcreate_log_3.txt
+echo "# Move otherA.dat DB files back to current directory"
+
+foreach x (`ls ./dbbkup3`)
+     mv ./dbbkup3/$x ./$x
+end
+
+echo '# Run testC of gtm8874.m'
+$ydb_dist/mumps -run testC^gtm8874


### PR DESCRIPTION
VIEW "[NO]STATSHARE"[:<region-list>] enables or disables database statistics sharing for listed regions which permit such sharing. Without the region-list, the command acts on all regions enabled for sharing. When a targeted region has sharing disabled, STATSHARE has no immediate effect, but may cause the process to start sharing if and when a MUPIP SET -STATS enables sharing for that region. Note: a VIEW "[NO]STATSHARE" with no region sub-argument opens any unopened mapped regions and any enabled associated statsDB regions; the $gtm_statshare environment variable applies to databases as the application first uses them. When the last VIEW "[NO]STATSHARE" had no region sub-argument, regions implicitly share when the process first references them, but after a VIEW specifies selective sharing, regions don't implicitly share as they open. Previously the VIEW command only supported enabling or disabling sharing for all enabled regions. (GTM-8874) [!Alert!] [!New Feature!]