### PR TITLE
Disable ydb_procstuckexec scheme on ARMV6L to prevent slowing down already slow-running tests

### DIFF
--- a/com/defaults_csh
+++ b/com/defaults_csh
@@ -181,7 +181,12 @@ check_setenv gtm_test_run_time "now"
 # Other environment and setup used by the test framework
 check_setenv ggdata $HOME
 check_setenv gtm_test_serverconf_file $gtm_tst/com/gg_servers.txt
+# On ARMV6L boxes (1-CPU system), we have seen C-stack tracing make an already slow running test even slower and resulting
+# in test failures. For now disable this feature in the hope this will prevent those system-slowness related test failures.
+if ("armv6l" != `uname -m`) then
 check_setenv gtm_procstuckexec $gtm_tst/com/gtmprocstuck_get_stack_trace.csh
+endif
+
 check_setenv gtm_linktmpdir /tmp/relinkdir/$USER
 
 setenv LC_COLLATE "C"


### PR DESCRIPTION
In one test failure, we saw an RF_SYNC take more than 3 hours to finish to clear the backlog
on the receiver side.

The hope is this will improve slow-running test runtimes enough to avoid test hangs/timeouts
on the ARMV6L platform.