### PR TITLE
Fix FILTERTIMEDOUT test failures on Linux/ARM by setting a bigger timeout of 1024 seconds (default is 64 seconds)

### DIFF
--- a/com/set_gtm_machtype.csh
+++ b/com/set_gtm_machtype.csh
@@ -57,9 +57,9 @@ endif
 # Set the variable for 32 bit architectures. Adding more 32bit platforms isn't likely
 if (($gtm_test_machtype == "ix86") || ($gtm_test_machtype == "armvxl")) then
 	setenv gtm_platform_size 32
-	# Increase replication filter timeout on the ARM as we have seen test failures
+	# Increase replication filter timeout on the ARM as we have seen test failures (particularly on ARMV6L)
 	# due to FILTERTIMEDOUT error in the source server log.
-	setenv ydb_repl_filter_timeout 256      # in seconds. This is 4 times default of 64 seconds
+	setenv ydb_repl_filter_timeout 1024	# in seconds. This is 16 times default of 64 seconds
 else
 	setenv gtm_platform_size 64
 endif


### PR DESCRIPTION
A previous commit bumped the timeout from the default of 64 seconds to 256 seconds.
But we still see occasional FILTERTIMEDOUT failures on the ARMV6L boxes.
Hoping this 4x bumping (from 256 to 1024 seconds) should address those failures completely.