### PR TITLE
Bump RF_sync.csh timeout from 3 hours to 12 hours (to prevent test failures on slow systems)

### DIFF
--- a/com/arguments.csh
+++ b/com/arguments.csh
@@ -3,6 +3,9 @@
 # Copyright (c) 2013-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -459,11 +462,6 @@ case "-non_tp":
 case "-NON_TP":
 	    ##HELP_SCREEN NON_TP  ($gtm_test_tp)
 	    setenv gtm_test_tp "NON_TP"
-breaksw
-case "-timeout":
-	    ##HELP_SCREEN  Test timeout ($test_timeout) is set to next argument
-	    setenv test_timeout $argv[$argc1]
-	    set skip
 breaksw
 case "-testtiminglog":
 	    ##HELP_SCREEN log results into timing.info

--- a/com/defaults_csh
+++ b/com/defaults_csh
@@ -133,7 +133,6 @@ check_setenv tst_remote_dir "default"
 check_number tst_buffsize 33554432
 check_setenv tst_rf_log "log"
 
-check_number test_timeout 10800
 check_number gtm_test_disk_limit 524288		# Minimum necessary disk space to start test
 check_number tst_gtcm_trace 0
 check_setenv tst_jnldir "default"

--- a/com/gtmtest.csh
+++ b/com/gtmtest.csh
@@ -769,7 +769,6 @@ endif
 if ($?test_replic) then
    echo "TEST REMOTE DIR:  $tst_remote_dir"			>> $confil
    echo "BUFFSIZE:         $tst_buffsize"			>> $confil
-   echo "TIMEOUT:          $test_timeout"			>> $confil
    echo "LOG:              $tst_rf_log"				>> $confil
    echo "TEST REMOTE JNL DIR:	$tst_remote_jnldir" 		>> $confil
    echo "TEST REMOTE BACKUP DIR:	$tst_remote_bakdir"	>> $confil

--- a/com/submit_test.csh
+++ b/com/submit_test.csh
@@ -3,7 +3,7 @@
 # Copyright (c) 2002-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -532,7 +532,6 @@ if ($?test_replic) then
    endif
    echo "gtm_repl_instance:	$gtm_repl_instance" 	>> $tst_general_dir/config.log
    echo "BUFFSIZE:            	$tst_buffsize" 		>> $tst_general_dir/config.log
-   echo "TIMEOUT:             	$test_timeout" 		>> $tst_general_dir/config.log
    echo "LOG:                 	$tst_rf_log" 		>> $tst_general_dir/config.log
    echo "JOURNAL:              	$tst_jnl_str" 		>> $tst_general_dir/config.log
 else

--- a/com/wait_until_src_backlog_below.csh
+++ b/com/wait_until_src_backlog_below.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2004, 2014 Fidelity Information Services, Inc	#
+# Copyright 2004, 2014 Fidelity Information Services, Inc	#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -58,14 +61,14 @@ set stacktrace = "${logfile:r}_stacktrace.out"
 $MUPIP replicate -source $gtm_test_instsecondary -checkhealth >&! $srcckhlth
 
 if ( 0 != `$grep -c 'alive in PASSIVE mode' $srcckhlth` ) then
-	echo "SRCBACKLOG-E-PASSIVE Source server is in PASSIVE mode"	 >&! $logfile
+	echo "SRCBACKLOG-E-PASSIVE Source server is in PASSIVE mode"	>>&! $logfile
 	cat $srcckhlth							>>&! $logfile
 	exit 1
 endif
 
 set pidsrc = `$tst_awk '/Source server is alive in ACTIVE mode/ { print $2}' $srcckhlth`
 if ( "" == "$pidsrc" ) then
-	echo "SRCBACKLOG-E-PID unable to obtain pid of source server"	 >&! $logfile
+	echo "SRCBACKLOG-E-PID unable to obtain pid of source server"	>>&! $logfile
 	cat $srcckhlth							>>&! $logfile
 	exit 1
 endif
@@ -74,7 +77,7 @@ while ($nowtime < $timeout)
 	$MUPIP replic -source $gtm_test_instsecondary -showbacklog >& $sblogfile
 	set backlog = `$tst_awk '/backlog number of transactions/ {print $1}' $sblogfile`
 	if ("" == "$backlog") then
-		echo "SRCBACKLOG-E-FAILED -showbacklog failed. Check $sblogfile"  >&! $logfile
+		echo "SRCBACKLOG-E-FAILED -showbacklog failed. Check $sblogfile" >>&! $logfile
 		cat $sblogfile							>>&! $logfile
 		exit 1
 	endif
@@ -84,13 +87,13 @@ while ($nowtime < $timeout)
 	set nowtime = `date +%s`
 end
 
-cat $sblogfile  >&! $logfile
+cat $sblogfile  >>&! $logfile
 if ($nowtime < $timeout) then
 	exit 0
 else
 	$gtm_tst/com/get_dbx_c_stack_trace.csh $pidsrc $gtm_exe/mupip	>>&! $stacktrace
 	# If noerror is set, just silently exit
 	if ($?noerror) exit 0
-	echo "SRCBACKLOG-E-TIMEOUT did not go below $limit in $maxwait seconds. Current backlog: $backlog"	 >&! $logfile
+	echo "SRCBACKLOG-E-TIMEOUT did not go below $limit in $maxwait seconds. Current backlog: $backlog"	 >>&! $logfile
 	exit 1
 endif


### PR DESCRIPTION
The 3 hour timeout was derived from the $test_timeout env var which was used only in one
place in the entire test system so all usages of this are now removed and instead a
hardcoded constant used instead in that one place.

While at this, com/wait_until_src_backlog_below.csh was enhanced so all usages of writes to
the logfile have been changed to append that way we don't inadvertently overwrite content
in the logfile that pre-existed before entry into this script.