### PR TITLE
New release for v63004/gtm8891. Tests the following release note: A <…

### DIFF
--- a/v63004/inref/gtm8891.m
+++ b/v63004/inref/gtm8891.m
@@ -1,0 +1,19 @@
+#
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# all rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license. If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+
+
+gtm8891()
+	w $incr(x)!$select(0:$incr(x))
+	quit
+

--- a/v63004/inref/gtm8891.m
+++ b/v63004/inref/gtm8891.m
@@ -1,19 +1,17 @@
-#
-#################################################################
-#								#
-# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
-# all rights reserved.						#
-#								#
-#	This source code contains the intellectual property	#
-#	of its copyright holder(s), and is made available	#
-#	under a license. If you do not know the terms of	#
-#	the license, please stop and do not read further.	#
-#								#
-#################################################################
-#
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; all rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license. If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
 gtm8891()
-	w $incr(x)!$select(0:$incr(x))
+	write $incr(x)!$select(0:$incr(x))
 	quit
 

--- a/v63004/instream.csh
+++ b/v63004/instream.csh
@@ -2,25 +2,26 @@
 #################################################################
 #								#
 # Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
-# All rights reserved.						#
+# all rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
-#	under a license.  If you do not know the terms of	#
+#	under a license. If you do not know the terms of	#
 #	the license, please stop and do not read further.	#
 #								#
 #################################################################
 #
 #-----------------------------------------------------------------------------------------------------------------------------
-# List of subtests of the form "subtestname [author] description"
+# list of subtests of the form "subtestname [author] description"
 #-----------------------------------------------------------------------------------------------------------------------------
-# gtm8909	    [jake]  Tests that <ctrl-c> within the help facility no longer leads to EN0256 error upon exit
-# gtm8860	    [jake]  Tests that journal extract removes additional / from journal and output file paths
-# gtm8791	    [jake]  Tests that <ctrl-z> no longer causes segmentation violation
-# gtm8699	    [jake]  Tests that $VIEW("STATSHARE",<region>) returns 1 if the process is sharing DB stats and 0 otherwise
-# gtm8202	    [jake]  Tests the functionality of the -SEQNO qualifier for the mupip journal -extract command
-# gtm5730	    [jake]  Tests that the update process now logs record types with a corresponding, non-numerical, description
-# gtm1041	    [jake]  Tests the that env variable gtm_mstack_size sets the size of the M stack as expected
+# gtm8909	    [jake]  tests that <ctrl-c> within the help facility no longer leads to en0256 error upon exit
+# gtm8891	    [vinay] testing for a select false runtime error in ydb when <side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) is run
+# gtm8860	    [jake]  tests that journal extract removes additional / from journal and output file paths
+# gtm8791	    [jake]  tests that <ctrl-z> no longer causes segmentation violation
+# gtm8699	    [jake]  tests that $view("statshare",<region>) returns 1 if the process is sharing db stats and 0 otherwise
+# gtm8202	    [jake]  tests the functionality of the -seqno qualifier for the mupip journal -extract command
+# gtm5730	    [jake]  tests that the update process now logs record types with a corresponding, non-numerical, description
+# gtm1041	    [jake]  tests the that env variable gtm_mstack_size sets the size of the m stack as expected
 #-----------------------------------------------------------------------------------------------------------------------------
 
 echo "v63004 test starts..."
@@ -28,7 +29,7 @@ echo "v63004 test starts..."
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
 setenv subtest_list_non_replic ""
-setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8860 gtm8791 gtm8699 gtm8202 gtm1041"
+setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8891 gtm8860 gtm8791 gtm8699 gtm8202 gtm1041"
 setenv subtest_list_replic     ""
 setenv subtest_list_replic     "$subtest_list_replic gtm5730"
 

--- a/v63004/instream.csh
+++ b/v63004/instream.csh
@@ -14,14 +14,14 @@
 #-----------------------------------------------------------------------------------------------------------------------------
 # List of subtests of the form "subtestname [author] description"
 #-----------------------------------------------------------------------------------------------------------------------------
-# gtm8909	    [jake]  Tests that <ctrl-c> within the help facility no longer leads to en0256 error upon exit
-# gtm8891	    [vinay] Testing for a select false runtime error in ydb when <side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) is run
+# gtm8909	    [jake]  Tests that <ctrl-c> within the help facility no longer leads to EN0256 error upon exit
 # gtm8860	    [jake]  Tests that journal extract removes additional / from journal and output file paths
 # gtm8791	    [jake]  Tests that <ctrl-z> no longer causes segmentation violation
-# gtm8699	    [jake]  Tests that $view("statshare",<region>) returns 1 if the process is sharing db stats and 0 otherwise
-# gtm8202	    [jake]  Tests the functionality of the -seqno qualifier for the mupip journal -extract command
+# gtm8699	    [jake]  Tests that $VIEW("STATSHARE",<region>) returns 1 if the process is sharing DB stats and 0 otherwise
+# gtm8202	    [jake]  Tests the functionality of the -SEQNO qualifier for the mupip journal -extract command
 # gtm5730	    [jake]  Tests that the update process now logs record types with a corresponding, non-numerical, description
-# gtm1041	    [jake]  Tests the that env variable gtm_mstack_size sets the size of the m stack as expected
+# gtm1041	    [jake]  Tests the that env variable gtm_mstack_size sets the size of the M stack as expected
+# gtm8891	    [vinay] Tests that <side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) sequence produces a SELECTFALSE runtime error
 #-----------------------------------------------------------------------------------------------------------------------------
 
 echo "v63004 test starts..."
@@ -29,7 +29,7 @@ echo "v63004 test starts..."
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
 setenv subtest_list_non_replic ""
-setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8891 gtm8860 gtm8791 gtm8699 gtm8202 gtm1041"
+setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8860 gtm8791 gtm8699 gtm8202 gtm1041"
 setenv subtest_list_replic     ""
 setenv subtest_list_replic     "$subtest_list_replic gtm5730"
 

--- a/v63004/instream.csh
+++ b/v63004/instream.csh
@@ -2,17 +2,17 @@
 #################################################################
 #								#
 # Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
-# all rights reserved.						#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
-#	under a license. If you do not know the terms of	#
+#	under a license.  If you do not know the terms of	#
 #	the license, please stop and do not read further.	#
 #								#
 #################################################################
 #
 #-----------------------------------------------------------------------------------------------------------------------------
-# list of subtests of the form "subtestname [author] description"
+# List of subtests of the form "subtestname [author] description"
 #-----------------------------------------------------------------------------------------------------------------------------
 # gtm8909	    [jake]  tests that <ctrl-c> within the help facility no longer leads to en0256 error upon exit
 # gtm8891	    [vinay] testing for a select false runtime error in ydb when <side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) is run

--- a/v63004/instream.csh
+++ b/v63004/instream.csh
@@ -14,14 +14,14 @@
 #-----------------------------------------------------------------------------------------------------------------------------
 # List of subtests of the form "subtestname [author] description"
 #-----------------------------------------------------------------------------------------------------------------------------
-# gtm8909	    [jake]  tests that <ctrl-c> within the help facility no longer leads to en0256 error upon exit
-# gtm8891	    [vinay] testing for a select false runtime error in ydb when <side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) is run
-# gtm8860	    [jake]  tests that journal extract removes additional / from journal and output file paths
-# gtm8791	    [jake]  tests that <ctrl-z> no longer causes segmentation violation
-# gtm8699	    [jake]  tests that $view("statshare",<region>) returns 1 if the process is sharing db stats and 0 otherwise
-# gtm8202	    [jake]  tests the functionality of the -seqno qualifier for the mupip journal -extract command
-# gtm5730	    [jake]  tests that the update process now logs record types with a corresponding, non-numerical, description
-# gtm1041	    [jake]  tests the that env variable gtm_mstack_size sets the size of the m stack as expected
+# gtm8909	    [jake]  Tests that <ctrl-c> within the help facility no longer leads to en0256 error upon exit
+# gtm8891	    [vinay] Testing for a select false runtime error in ydb when <side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) is run
+# gtm8860	    [jake]  Tests that journal extract removes additional / from journal and output file paths
+# gtm8791	    [jake]  Tests that <ctrl-z> no longer causes segmentation violation
+# gtm8699	    [jake]  Tests that $view("statshare",<region>) returns 1 if the process is sharing db stats and 0 otherwise
+# gtm8202	    [jake]  Tests the functionality of the -seqno qualifier for the mupip journal -extract command
+# gtm5730	    [jake]  Tests that the update process now logs record types with a corresponding, non-numerical, description
+# gtm1041	    [jake]  Tests the that env variable gtm_mstack_size sets the size of the m stack as expected
 #-----------------------------------------------------------------------------------------------------------------------------
 
 echo "v63004 test starts..."

--- a/v63004/instream.csh
+++ b/v63004/instream.csh
@@ -29,7 +29,7 @@ echo "v63004 test starts..."
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
 setenv subtest_list_non_replic ""
-setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8860 gtm8791 gtm8699 gtm8202 gtm1041"
+setenv subtest_list_non_replic "$subtest_list_non_replic gtm8909 gtm8860 gtm8791 gtm8699 gtm8202 gtm1041 gtm8891"
 setenv subtest_list_replic     ""
 setenv subtest_list_replic     "$subtest_list_replic gtm5730"
 

--- a/v63004/outref/gtm8891.txt
+++ b/v63004/outref/gtm8891.txt
@@ -1,0 +1,5 @@
+#Running gtm8891 test
+%YDB-E-SELECTFALSE, No argument to $SELECT was true
+		At M source location gtm8891+1^gtm8891
+
+YDB>

--- a/v63004/outref/outref.txt
+++ b/v63004/outref/outref.txt
@@ -1,6 +1,7 @@
 v63004 test starts...
 ##SUSPEND_OUTPUT REPLIC
 PASS from gtm8909
+PASS from gtm8891
 PASS from gtm8860
 PASS from gtm8791
 PASS from gtm8699

--- a/v63004/outref/outref.txt
+++ b/v63004/outref/outref.txt
@@ -1,12 +1,12 @@
 v63004 test starts...
 ##SUSPEND_OUTPUT REPLIC
 PASS from gtm8909
-PASS from gtm8891
 PASS from gtm8860
 PASS from gtm8791
 PASS from gtm8699
 PASS from gtm8202
 PASS from gtm1041
+PASS from gtm8891
 ##ALLOW_OUTPUT REPLIC
 ##SUSPEND_OUTPUT NONREPLIC
 PASS from gtm5730

--- a/v63004/u_inref/gtm8891.csh
+++ b/v63004/u_inref/gtm8891.csh
@@ -1,4 +1,3 @@
-
 #################################################################
 #								#
 # Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
@@ -10,8 +9,7 @@
 #	the license, please stop and do not read further.	#
 #								#
 #################################################################
-#
+
 
 echo "#Running gtm8891 test"
 $gtm_dist/mumps -run gtm8891
-$gtm_dist/mumps -run %XCMD 'halt'

--- a/v63004/u_inref/gtm8891.csh
+++ b/v63004/u_inref/gtm8891.csh
@@ -1,0 +1,17 @@
+
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# all rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license. If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+
+echo "#Running gtm8891 test"
+$gtm_dist/mumps -run gtm8891
+$gtm_dist/mumps -run %XCMD 'halt'


### PR DESCRIPTION
…side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) sequence produces a SELECTFALSE run-time error; a regression introduced with the literal optimizations in V6.3-002 caused this combination to produce a SIG-11 (segmentation violation) at compilation. (GTM-8891)