### PR TITLE
Tests for v63003/gtm7986 (tests GTM7986 in V63003)

### DIFF
--- a/v63003/inref/gtm7986.m
+++ b/v63003/inref/gtm7986.m
@@ -1,0 +1,21 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; Generating an m program which prints a string that is too long
+;
+gtm7986
+	set bigstring=$justify(1,8192,8192)
+	set x="temp.m"
+	open x
+        use x write " write "_bigstring,!
+	quit
+

--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -15,13 +15,14 @@
 # List of subtests of the form "subtestname [author] description"
 #-------------------------------------------------------------------------------------
 # gtm8788           [nars]  Test that BLKTOODEEP error lines are excluded from object file (GTM-8788 fixed in GT.M V6.3-003)
+# gtm7986	    [vinay] Test that a line of over 8192 bytes produces an LSINSERTED warning
 #-------------------------------------------------------------------------------------
 
 echo "v63003 test starts..."
 
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
-setenv subtest_list_non_replic "gtm8788"
+setenv subtest_list_non_replic "gtm8788 gtm7986"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/v63003/outref/gtm7986.txt
+++ b/v63003/outref/gtm7986.txt
@@ -1,0 +1,4 @@
+# Generating an M file with big string
+# Attempting to run file
+%YDB-W-LSINSERTED, Line 1, source module ##IN_TEST_PATH##/inref/temp.m exceeds maximum source line length; line seperator inserted, terminating scope of any prior IF, ELSE, or FOR
+1

--- a/v63003/outref/outref.txt
+++ b/v63003/outref/outref.txt
@@ -1,5 +1,6 @@
 v63003 test starts...
 ##SUSPEND_OUTPUT REPLIC
 PASS from gtm8788
+PASS from gtm7986
 ##ALLOW_OUTPUT REPLIC
 v63003 test DONE.

--- a/v63003/u_inref/gtm7986.csh
+++ b/v63003/u_inref/gtm7986.csh
@@ -1,0 +1,21 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Test that a line length greater than 8192 bytes produces a LSEXPECTED warning
+#
+
+echo "# Generating an M file with big string"
+$ydb_dist/mumps -run gtm7986
+
+echo "# Attempting to run file"
+$ydb_dist/mumps -run temp


### PR DESCRIPTION
Tests the following release note:

When GT.M encounters a line with a length greater than 8192 bytes in a source file, it emits a %GTM-W-LSINSERTED warning. This warning identifies cases where a line greater than 8192 bytes is split into multiple lines, which causes statements beyond the character prior to the limit to execute irrespective of any starting IF, ELSE or FOR commands. Previously, GT.M split the lines with no warning. (GTM-7986)

