### PR TITLE
New tests for v63006/gtm8186 and fix to gtm7986 outref file

### DIFF
--- a/v63003/inref/gtm8186.m
+++ b/v63003/inref/gtm8186.m
@@ -1,0 +1,45 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Tests goto, zgoto, and do by running each command with an
+; offset that prints a unique statement to indicate success
+;
+gtm8186
+	do testgoto
+	do testdo
+	do testzgoto
+	quit
+
+gotomessage
+	write "goto passed",!
+	quit
+
+domessage
+	write "do passed",!
+	quit
+
+zogotmessage
+	write "zgoto passed",!
+	quit
+
+testgoto
+	GOTO +22^gtm8186
+	quit
+
+testdo
+	DO +25^gtm8186
+	quit
+
+testzgoto
+	ZGOTO $ZLEVEL:+30^gtm8186
+	quit
+
+

--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -16,13 +16,14 @@
 #-------------------------------------------------------------------------------------
 # gtm8788           [nars]  Test that BLKTOODEEP error lines are excluded from object file (GTM-8788 fixed in GT.M V6.3-003)
 # gtm7986	    [vinay] Test that a line of over 8192 bytes produces an LSINSERTED warning
+# gtm8186	    [vinay] Test DO, GOTO and ZGOTO can take offset without a label
 #-------------------------------------------------------------------------------------
 
 echo "v63003 test starts..."
 
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
-setenv subtest_list_non_replic "gtm8788 gtm7986"
+setenv subtest_list_non_replic "gtm8788 gtm7986 gtm8186"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/v63003/outref/gtm7986.txt
+++ b/v63003/outref/gtm7986.txt
@@ -1,4 +1,4 @@
 # Generating an M file with big string
 # Attempting to run file
-%YDB-W-LSINSERTED, Line 1, source module ##IN_TEST_PATH##/inref/temp.m exceeds maximum source line length; line seperator inserted, terminating scope of any prior IF, ELSE, or FOR
+%YDB-W-LSINSERTED, Line 1, source module ##TEST_PATH##/temp.m exceeds maximum source line length; line seperator inserted, terminating scope of any prior IF, ELSE, or FOR
 1

--- a/v63003/outref/gtm8186.txt
+++ b/v63003/outref/gtm8186.txt
@@ -1,0 +1,4 @@
+# Testing goto, do and zgoto
+goto passed
+do passed
+zgoto passed

--- a/v63003/outref/outref.txt
+++ b/v63003/outref/outref.txt
@@ -2,5 +2,6 @@ v63003 test starts...
 ##SUSPEND_OUTPUT REPLIC
 PASS from gtm8788
 PASS from gtm7986
+PASS from gtm8186
 ##ALLOW_OUTPUT REPLIC
 v63003 test DONE.

--- a/v63003/u_inref/gtm8186.csh
+++ b/v63003/u_inref/gtm8186.csh
@@ -1,0 +1,19 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Testing if do, goto and zgoto can be run with an offset but no
+# labels
+
+echo "# Testing goto, do and zgoto"
+$ydb_dist/mumps -run gtm8186
+


### PR DESCRIPTION
Tests the following release note: 

GT.M accepts an offset without a label for an entryref argument to DO, GOTO and ZGOTO. FIS recommends restricting the use of offsets in entryrefs to debugging, error handling and testing. Previously GT.M required a label before any offset. (GTM-8186) 

Unites outref file for gtm7986 for generality