### PR TITLE
Test for v63003/gtm8832 (tests GTM-8832 in V63003)

### DIFF
--- a/v63003/inref/gtm8832.m
+++ b/v63003/inref/gtm8832.m
@@ -1,0 +1,21 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; Testing a string literal greater than or equal to 1E47 causes a NUMOFLOW error
+;
+gtm8832
+	write !,!,"Evaluation of 1E46",!
+	write +"1E46"
+	write !,!,"Evaluation of 1E47",!
+	write +"1E47"
+	quit
+

--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -18,13 +18,14 @@
 # gtm7986	    [vinay] Test that a line of over 8192 bytes produces an LSINSERTED warning
 # gtm8186	    [vinay] Test DO, GOTO and ZGOTO can take offset without a label
 # gtm8804	    [vinay] Test zshow "t" produces only a summary of zshow "g" and "l"
+# gtm8832	    [vinay] Test string literal evaluating to >=1E47 produces a NUMOFLOW error
 #-------------------------------------------------------------------------------------
 
 echo "v63003 test starts..."
 
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
-setenv subtest_list_non_replic "gtm8788 gtm7986 gtm8186 gtm8804"
+setenv subtest_list_non_replic "gtm8788 gtm7986 gtm8186 gtm8804 gtm8832"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/v63003/outref/gtm8832.txt
+++ b/v63003/outref/gtm8832.txt
@@ -1,0 +1,15 @@
+# Evaluating for 1E46 and 1E47
+		write +"1E47"
+		             ^-----
+		At column 15, line 19, source module ##IN_TEST_PATH##/inref/gtm8832.m
+%YDB-E-NUMOFLOW, Numeric overflow
+
+
+Evaluation of 1E46
+10000000000000000000000000000000000000000000000
+
+Evaluation of 1E47
+%YDB-E-NUMOFLOW, Numeric overflow
+		At M source location gtm8832+4^gtm8832
+
+YDB>

--- a/v63003/outref/outref.txt
+++ b/v63003/outref/outref.txt
@@ -4,5 +4,6 @@ PASS from gtm8788
 PASS from gtm7986
 PASS from gtm8186
 PASS from gtm8804
+PASS from gtm8832
 ##ALLOW_OUTPUT REPLIC
 v63003 test DONE.

--- a/v63003/u_inref/gtm8832.csh
+++ b/v63003/u_inref/gtm8832.csh
@@ -1,0 +1,18 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Tests if string literal evaluated as a number greater than or
+# equal to 1E47 produces a NUMOFLOW error
+
+echo "# Evaluating for 1E46 and 1E47"
+$ydb_dist/mumps -run gtm8832


### PR DESCRIPTION
Tests the following release note:

GT.M reports a NUMOFLOW error for a string literal used as a number and evaluating to a number that exceeds the supported range, as of this writing: 1E47. A compiler optimization in V6.3-001[A] caused such an evaluation to produce a very very small negative value. (GTM-8832)