### PR TITLE
Fix occasional v62000/gtm8086 test failure on slow systems where a journal file switch can sometimes take more than 5 minutes

### DIFF
--- a/v62000/u_inref/gtm8086.csh
+++ b/v62000/u_inref/gtm8086.csh
@@ -74,7 +74,7 @@ $gtm_tst/com/imptp.csh >>&! imptp.out
 
 @ logcount = $num_regions + 1	# Wait for at least one journal file switch
 
-(cd $jnldir ; $gtm_tst/com/wait_for_n_jnl.csh -lognum $logcount -duration 300)
+(cd $jnldir ; $gtm_tst/com/wait_for_n_jnl.csh -lognum $logcount -duration 3600)
 
 echo ">>> Set jnldir read-only"
 


### PR DESCRIPTION
Bump the max-timeout from 5 minutes to 1 hour.