### PR TITLE
Test for v63003/gtm8617 (Tests GTM-8617 in V63003)

### DIFF
--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -19,7 +19,7 @@
 # gtm8186	    [vinay] Test DO, GOTO and ZGOTO can take offset without a label
 # gtm8804	    [vinay] Test zshow "t" produces only a summary of zshow "g" and "l"
 # gtm8832	    [vinay] Test string literal evaluating to >=1E47 produces a NUMOFLOW error
-# gtm8617	    [vinay] Tests functionality of STDNULLCOLL and NULL_SUBSCRIPTS
+# gtm8617	    [vinay] Tests MUPIP SET command of STDNULLCOLL and NULL_SUBSCRIPTS
 #-------------------------------------------------------------------------------------
 
 echo "v63003 test starts..."

--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -19,13 +19,14 @@
 # gtm8186	    [vinay] Test DO, GOTO and ZGOTO can take offset without a label
 # gtm8804	    [vinay] Test zshow "t" produces only a summary of zshow "g" and "l"
 # gtm8832	    [vinay] Test string literal evaluating to >=1E47 produces a NUMOFLOW error
+# gtm8617	    [vinay] Tests functionality of STDNULLCOLL and NULL_SUBSCRIPTS
 #-------------------------------------------------------------------------------------
 
 echo "v63003 test starts..."
 
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
-setenv subtest_list_non_replic "gtm8788 gtm7986 gtm8186 gtm8804 gtm8832"
+setenv subtest_list_non_replic "gtm8788 gtm7986 gtm8186 gtm8804 gtm8832 gtm8617"
 setenv subtest_list_replic     ""
 
 if ($?test_replic == 1) then

--- a/v63003/outref/gtm8617.txt
+++ b/v63003/outref/gtm8617.txt
@@ -1,0 +1,10 @@
+# Null subscript set to never
+Database file ##TEST_PATH##/mumps.dat now has null subscripts set to NEVER   
+# Null subscript set to existing
+Database file ##TEST_PATH##/mumps.dat now has null subscripts set to EXISTING
+# Null subscript set to always
+Database file ##TEST_PATH##/mumps.dat now has null subscripts set to ALWAYS  
+# Null collation set to GT.M
+Database file ##TEST_PATH##/mumps.dat is now using M standard null collation
+# Null collation set to M
+Database file ##TEST_PATH##/mumps.dat is now using GT.M null collation      

--- a/v63003/outref/gtm8617.txt
+++ b/v63003/outref/gtm8617.txt
@@ -1,10 +1,17 @@
 # Null subscript set to never
 Database file ##TEST_PATH##/mumps.dat now has null subscripts set to NEVER   
+  Null subscripts                     NEVER  Free blocks             0x00000062
 # Null subscript set to existing
 Database file ##TEST_PATH##/mumps.dat now has null subscripts set to EXISTING
+  Null subscripts                  EXISTING  Free blocks             0x00000062
 # Null subscript set to always
 Database file ##TEST_PATH##/mumps.dat now has null subscripts set to ALWAYS  
-# Null collation set to GT.M
-Database file ##TEST_PATH##/mumps.dat is now using M standard null collation
+  Null subscripts                    ALWAYS  Free blocks             0x00000062
+# Null subscript set to an option not listed (expecting an error)
+%YDB-E-CLIERR, Unrecognized option : SOMETIMES
 # Null collation set to M
+Database file ##TEST_PATH##/mumps.dat is now using M standard null collation
+  Standard Null Collation              TRUE  Free space              0x00000000
+# Null collation set to GT.M
 Database file ##TEST_PATH##/mumps.dat is now using GT.M null collation      
+  Standard Null Collation             FALSE  Free space              0x00000000

--- a/v63003/outref/outref.txt
+++ b/v63003/outref/outref.txt
@@ -5,5 +5,6 @@ PASS from gtm7986
 PASS from gtm8186
 PASS from gtm8804
 PASS from gtm8832
+PASS from gtm8617
 ##ALLOW_OUTPUT REPLIC
 v63003 test DONE.

--- a/v63003/u_inref/gtm8617.csh
+++ b/v63003/u_inref/gtm8617.csh
@@ -16,36 +16,35 @@
 
 echo "# Null subscript set to never"
 $gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
-$ydb_dist/mupip set -region DEFAULT -N=never
+$ydb_dist/mupip set -region DEFAULT -Null_SUBSCRIPTS=never
+$DSE dump -file|&grep "Null subscripts"
 $gtm_tst/com/dbcheck.csh >& db.txt
 
 echo "# Null subscript set to existing"
 $gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
-$ydb_dist/mupip set -region DEFAULT -N=existing
+$ydb_dist/mupip set -region DEFAULT -NULL_SUBSCRIPTS=existing
+$DSE dump -file|&grep "Null subscripts"
 $gtm_tst/com/dbcheck.csh >& db.txt
 
 echo "# Null subscript set to always"
 $gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
-$ydb_dist/mupip set -region DEFAULT -N=always
+$ydb_dist/mupip set -region DEFAULT -NULL_SUBSCRIPTS=always
+$DSE dump -file|&grep "Null subscripts"
 $gtm_tst/com/dbcheck.csh >& db.txt
 
-echo "# Null collation set to GT.M"
+echo "# Null subscript set to an option not listed (expecting an error)"
 $gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
-$ydb_dist/mupip set -region DEFAULT -std
+$ydb_dist/mupip set -region DEFAULT -NULL_SUBSCRIPTS=sometimes
 $gtm_tst/com/dbcheck.csh >& db.txt
 
 echo "# Null collation set to M"
 $gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
-$ydb_dist/mupip set -region DEFAULT -nostd
+$ydb_dist/mupip set -region DEFAULT -STDNULLCOLL
+$DSE dump -file|&grep "Standard Null Collation"
 $gtm_tst/com/dbcheck.csh >& db.txt
 
-
-
-
-
-
-
-
-
-
-
+echo "# Null collation set to GT.M"
+$gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
+$ydb_dist/mupip set -region DEFAULT -NOSTDNULLCOLL
+$DSE dump -file|&grep "Standard Null Collation"
+$gtm_tst/com/dbcheck.csh >& db.txt

--- a/v63003/u_inref/gtm8617.csh
+++ b/v63003/u_inref/gtm8617.csh
@@ -1,0 +1,51 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Case for each functionality described in the release note
+#
+
+echo "# Null subscript set to never"
+$gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
+$ydb_dist/mupip set -region DEFAULT -N=never
+$gtm_tst/com/dbcheck.csh >& db.txt
+
+echo "# Null subscript set to existing"
+$gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
+$ydb_dist/mupip set -region DEFAULT -N=existing
+$gtm_tst/com/dbcheck.csh >& db.txt
+
+echo "# Null subscript set to always"
+$gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
+$ydb_dist/mupip set -region DEFAULT -N=always
+$gtm_tst/com/dbcheck.csh >& db.txt
+
+echo "# Null collation set to GT.M"
+$gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
+$ydb_dist/mupip set -region DEFAULT -std
+$gtm_tst/com/dbcheck.csh >& db.txt
+
+echo "# Null collation set to M"
+$gtm_tst/com/dbcreate.csh mumps 1 >>& db.txt
+$ydb_dist/mupip set -region DEFAULT -nostd
+$gtm_tst/com/dbcheck.csh >& db.txt
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Tests the following release note:

The MUPIP SET command supports the following qualifiers: -N[ULL_SUBSCRIPTS]={never, always, existing}, which controls whether GT.M accepts null subscripts for database keys. -[NO]STD[NULLCOLL], which determines whether GT.M will use standard MUMPS collation or GT.M collation for null-subscripted keys. Previously, this functionality was only available through GDE for database file creation, and DSE for existing database files. FIS strongly recommends avoiding the use of DSE when there is an alternative. (GTM-8617)