### PR TITLE
Fix suppl_inst_B_1/fetchresync_nosupplsupplgroup test failure due to test taking > 10 hours to finish on ARMV6L

### DIFF
--- a/com/gtm_test_watchdog.csh
+++ b/com/gtm_test_watchdog.csh
@@ -22,7 +22,7 @@ set shorthost = $HOST:r:r:r:r
 set format="%Y.%m.%d.%H.%M.%S.%Z"
 set timestart = `date +"$format"`
 if (! $?gtm_test_hang_alert_sec) then
-	if ($gtm_test_singlecpu || ) then
+	if ($gtm_test_singlecpu) then
 		# 1-CPU armv7l/armv6l/x86_64 box. Set a high hang alert for 1-CPU systems (slow boxes)
 		set gtm_test_hang_alert_sec = 36000 # A subtest running for 10 hours on a 1-CPU system is suspected to be hung
 	else if ("HOST_LINUX_ARMVXL" != $gtm_test_os_machtype) then

--- a/com/set_gtm_test_wait_factor.csh
+++ b/com/set_gtm_test_wait_factor.csh
@@ -1,0 +1,24 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+
+# This script is invoked from tests which need to speed up the update rate of SLOWFILL.
+# Default update rate is 1 update per second.
+# Callers of this script though will get an update rate of 50 updates per second (i.e. one update every 0.02 seconds)
+# If this is a 1-CPU box though, we have seen many hours for the backlog to clear in some tests so we set the
+#	update rate at 10 updates per second (i.e. one update every 0.01 seconds).
+
+if (! $gtm_test_singlecpu) then
+	setenv gtm_test_wait_factor 0.02
+else
+	setenv gtm_test_wait_factor 0.10
+endif

--- a/com/wait_until_rcvr_backlog_below.csh
+++ b/com/wait_until_rcvr_backlog_below.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2014 Fidelity Information Services, Inc	#
+# Copyright 2014 Fidelity Information Services, Inc		#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -58,6 +61,9 @@ if ( ("" == "$pidrcv") || ("" == "$pidupd") ) then
 endif
 
 while ($nowtime < $timeout)
+	echo "---------------------------------------------------------------"	>>&! ${logfile:r}_trace.out
+	echo "Current Time is : `date`"						>>&! ${logfile:r}_trace.out
+	echo "---------------------------------------------------------------"	>>&! ${logfile:r}_trace.out
 	$MUPIP replic -receiv -showbacklog >& $sblogfile
 	set backlog = `$tst_awk '/backlog/ {print $1}' $sblogfile`
 	if ("" == "$backlog") then

--- a/com/wait_until_src_backlog_below.csh
+++ b/com/wait_until_src_backlog_below.csh
@@ -74,6 +74,9 @@ if ( "" == "$pidsrc" ) then
 endif
 
 while ($nowtime < $timeout)
+	echo "---------------------------------------------------------------"	>>&! ${logfile:r}_trace.out
+	echo "Current Time is : `date`"						>>&! ${logfile:r}_trace.out
+	echo "---------------------------------------------------------------"	>>&! ${logfile:r}_trace.out
 	$MUPIP replic -source $gtm_test_instsecondary -showbacklog >& $sblogfile
 	set backlog = `$tst_awk '/backlog number of transactions/ {print $1}' $sblogfile`
 	if ("" == "$backlog") then

--- a/suppl_inst_A/u_inref/instance_recreate.csh
+++ b/suppl_inst_A/u_inref/instance_recreate.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2012, 2013 Fidelity Information Services, Inc	#
+# Copyright 2012, 2013 Fidelity Information Services, Inc	#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -33,17 +36,14 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 unsetenv needupdatersync
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and P and let them replicate to B, P and Q as appropriate"
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 $MSR STOPRCV INST3 INST4

--- a/suppl_inst_B/u_inref/fetchresync_nosupplsupplgroup.csh
+++ b/suppl_inst_B/u_inref/fetchresync_nosupplsupplgroup.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -36,17 +39,14 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 unsetenv needupdatersync
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and P and let them replicate to B, P and Q as appropriate"
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 setenv gtm_test_other_bg_processes
@@ -64,7 +64,7 @@ $MSR RUN  INST1 "mkdir bak1; $MUPIP backup -replinstance=bak1 "'"*" bak1' >&! in
 $MSR START INST2 INST1 RP
 $MSR START INST2 INST3 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over from P to Q
@@ -80,7 +80,7 @@ $MSR START INST4 INST3 RP
 $MSR START INST2 INST4 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_2.out
 $MSR RUN INST4 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst4_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over back from B to A
@@ -96,7 +96,7 @@ $MSR RUN  INST2 "mkdir bak1; $MUPIP backup -replinstance=bak1 "'"*" bak1' >&! in
 $MSR START INST1 INST2 RP
 $MSR START INST1 INST4 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over back from Q to P

--- a/suppl_inst_B/u_inref/noresync_2.csh
+++ b/suppl_inst_B/u_inref/noresync_2.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -36,17 +39,14 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 unsetenv needupdatersync
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and P and let them replicate to B, P and Q as appropriate"
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over from A to B
@@ -60,7 +60,7 @@ $MSR STOP INST1 INST3
 $MSR START INST2 INST1 RP
 $MSR START INST2 INST3 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 echo
@@ -73,7 +73,7 @@ $MSR STOP INST2 INST3
 $MSR START INST1 INST2 RP
 $MSR START INST1 INST3 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 #Stop updates on A and P

--- a/suppl_inst_B/u_inref/upgrade_inst.csh
+++ b/suppl_inst_B/u_inref/upgrade_inst.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -35,16 +38,13 @@ echo "===>Start replication A->B"
 echo
 $MSR START INST1 INST2 RP
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and let them replicate to B."
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/endtp.csh' >&! endtp_inst1_1.out

--- a/suppl_inst_C/u_inref/multiple_switchover.csh
+++ b/suppl_inst_C/u_inref/multiple_switchover.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2012, 2013 Fidelity Information Services, Inc	#
+# Copyright 2012, 2013 Fidelity Information Services, Inc	#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -40,17 +43,14 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 unsetenv needupdatersync
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and P and let them replicate to B, P and Q as appropriate"
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over from A to B
@@ -63,7 +63,7 @@ $MSR STOP INST1 INST3
 $MSR START INST2 INST1 RP
 $MSR START INST2 INST3 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over from P to Q
@@ -78,7 +78,7 @@ $MSR START INST4 INST3 RP
 $MSR START INST2 INST4 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_2.out
 $MSR RUN INST4 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst4_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over back from B to A
@@ -91,7 +91,7 @@ $MSR STOP INST2 INST4
 $MSR START INST1 INST2 RP
 $MSR START INST1 INST4 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over back from Q to P
@@ -106,7 +106,7 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_3.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Stop updates on A and P

--- a/suppl_inst_D/u_inref/fetchresync_supplgroup.csh
+++ b/suppl_inst_D/u_inref/fetchresync_supplgroup.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -46,10 +49,7 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 unsetenv needupdatersync
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and P and let them replicate to B, P and Q as appropriate"
@@ -57,7 +57,7 @@ echo
 # The first digit in jobid and dibfillid indicates the instance ID while second digits indicates number of times updates are started on the given instance.
 $MSR RUN INST1 'setenv gtm_test_jobid 11 ; setenv gtm_test_dbfillid 11 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 31 ; setenv gtm_test_dbfillid 31 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 setenv gtm_test_other_bg_processes
@@ -70,7 +70,7 @@ $MSR STOP INST1 INST2
 $MSR STOP INST1 INST3
 $MSR STARTSRC INST2 INST1 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 21 ; setenv gtm_test_dbfillid 21 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 $MSR RUN RCV=INST1 SRC=INST2 '$gtm_tst/com/mupip_rollback.csh -fetchresync=__RCV_PORTNO__ -losttrans=lost1.glo "*" >&! rollback_1.out; $grep "Rollback successful" rollback_1.out'
 $MSR STARTRCV INST2 INST1
@@ -84,11 +84,11 @@ $MSR RUN INST3 'setenv gtm_test_jobid 31 ; setenv gtm_test_dbfillid 31 ; $gtm_ts
 $MSR STOP INST2 INST3
 $MSR STOP INST3 INST4
 $MSR RUN INST2 'setenv gtm_test_jobid 22 ; setenv gtm_test_dbfillid 22 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 $MSR STARTSRC INST4 INST3 RP
 $MSR RUN INST4 'setenv gtm_test_jobid 41 ; setenv gtm_test_dbfillid 41 ; $gtm_tst/com/imptp.csh' >&! imptp_inst4_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 $MSR RUN RCV=INST3 SRC=INST4 '$gtm_tst/com/mupip_rollback.csh -fetchresync=__RCV_PORTNO__ -losttrans=lost1.glo "*" >&! rollback_2.out; $grep "Rollback successful" rollback_2.out'
 $MSR STARTRCV INST4 INST3
@@ -102,7 +102,7 @@ $MSR STOP INST2 INST1
 $MSR STOP INST2 INST4
 $MSR STARTSRC INST1 INST2 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 12 ; setenv gtm_test_dbfillid 12 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 $MSR RUN RCV=INST2 SRC=INST1 '$gtm_tst/com/mupip_rollback.csh -fetchresync=__RCV_PORTNO__ -losttrans=lost1.glo "*" >&! rollback_3.out; $grep "Rollback successful" rollback_3.out'
 $MSR STARTRCV INST1 INST2
@@ -116,11 +116,11 @@ $MSR RUN INST1 'setenv gtm_test_jobid 12 ; setenv gtm_test_dbfillid 12 ; $gtm_ts
 $MSR STOP INST1 INST4
 $MSR STOP INST4 INST3
 $MSR RUN INST1 'setenv gtm_test_jobid 13 ; setenv gtm_test_dbfillid 13 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_3.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 $MSR STARTSRC INST3 INST4 RP
 $MSR RUN INST3 'setenv gtm_test_jobid 32 ; setenv gtm_test_dbfillid 32 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 $MSR RUN RCV=INST4 SRC=INST3 '$gtm_tst/com/mupip_rollback.csh -fetchresync=__RCV_PORTNO__ -losttrans=lost1.glo "*" >&! rollback_4.out; $grep "Rollback successful" rollback_4.out'
 $MSR STARTRCV INST3 INST4

--- a/suppl_inst_D/u_inref/noresync_1.csh
+++ b/suppl_inst_D/u_inref/noresync_1.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -36,17 +39,14 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 unsetenv needupdatersync
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and P and let them replicate to B, P and Q as appropriate"
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 echo
@@ -60,7 +60,7 @@ $MSR RUN  INST1 "mkdir bak1; $MUPIP backup -replinstance=bak1 "'"*" bak1' >&! in
 $MSR STARTSRC INST1 INST2 RP
 $MSR STARTSRC INST1 INST3 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 echo

--- a/suppl_inst_D/u_inref/supplgrouprepl.csh
+++ b/suppl_inst_D/u_inref/supplgrouprepl.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2012, 2013 Fidelity Information Services, Inc	#
+# Copyright 2012, 2013 Fidelity Information Services, Inc	#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -36,17 +39,14 @@ $MSR START INST3 INST4 RP
 $MSR START INST1 INST3 RP
 unsetenv needupdatersync
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and P and let them replicate to B, P and Q as appropriate"
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over from A to B
@@ -58,7 +58,7 @@ $MSR STOP INST1 INST3
 $MSR START INST2 INST1 RP
 $MSR START INST2 INST3 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Shut down Q side of P->Q link
@@ -74,7 +74,7 @@ $MSR STOP INST2 INST3
 $MSR START INST1 INST2 RP
 $MSR START INST1 INST3 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over from A to B
@@ -86,7 +86,7 @@ $MSR STOP INST1 INST3
 $MSR START INST2 INST1 RP
 $MSR START INST2 INST3 RP
 $MSR RUN INST2 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst2_2.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Switch over back from B to A
@@ -98,7 +98,7 @@ $MSR STOP INST2 INST3
 $MSR START INST1 INST2 RP
 $MSR START INST1 INST3 RP
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_3.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Restart Q side of P->Q link

--- a/suppl_inst_D/u_inref/upgrade_inst1.csh
+++ b/suppl_inst_D/u_inref/upgrade_inst1.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -46,16 +49,13 @@ unsetenv needupdatersync
 
 $MSR STOPRCV INST3 INST4
 
-# Also because this test does SLOWFILL type of updates, we need to have a very small inter-update time (gtm_test_wait_factor)
-# in order to exercise jnl autoswitch. But because we do not want a lot of updates, the inter-update time should not be too
-# low either. Therefore we currently maintain it at 0.02. This value needs to be changed with care.
-setenv gtm_test_wait_factor 0.02 # 0.02 second delay between updates in slowfill.m. See comment above for why it is what it is
+source $gtm_tst/com/set_gtm_test_wait_factor.csh	# set gtm_test_wait_factor env var to control SLOWFILL rate of updates
 
 echo
 echo "===>Do some updates on A and let them replicate to B."
 echo
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/imptp.csh' >&! imptp_inst1_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 
 # Now we want to upgrade a backup of B to P. So take a backup of B first
@@ -89,7 +89,7 @@ unsetenv needupdatersync
 
 # Make few updates on the INST3.
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfill "SLOWFILL" ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/imptp.csh' >&! imptp_inst3_1.out
-# Following sleep along with environment variable gtm_test_wait_factor ensure that there will be reasonable updates on instance A and P before switchover
+# Following sleep along with environment variable gtm_test_wait_factor ensures that there will be reasonable updates on instance A and P before switchover
 sleep 1
 $MSR RUN INST1 'setenv gtm_test_jobid 1 ; setenv gtm_test_dbfillid 1 ; $gtm_tst/com/endtp.csh' >&! endtp_inst1_1.out
 $MSR RUN INST3 'setenv gtm_test_jobid 2 ; setenv gtm_test_dbfillid 2 ; $gtm_tst/com/endtp.csh' >&! endtp_inst3_1.out


### PR DESCRIPTION
On the Raspberry Pi Zero, an armv6l architecture 1-CPU box, the
suppl_inst_B_1/fetchresync_nosupplsupplgroup test took 14 hours to finish which exceeded
the 10 hour hangalert threshold in the test system framework. Out of the 14 hours, 9.5
hours were spent waiting for the backlog to clear in two RF_sync calls. To address this,
the rate of SLOWFILL updates is now reduced to 10 updates per second (instead of 50
updates per second) for 1-CPU systems. This is achieved by setting gtm_test_wait_factor
env var, the inter-update delay in seconds, to 0.10 (instead of 0.02) seconds. A new
com/set_gtm_test_wait_factor.csh script is now invoked by various suppl_inst_* subtests
(to avoid code duplication) and that takes care of this setenv. It keeps the update
rate unchanged for systems with more than 1 CPU.

Additionally, the following fixes were done

* com/gtm_test_watchdog.csh : Fix a || usage that did not have any operand following it.

* com/wait_until_rcvr_backlog_below.csh & com/wait_until_src_backlog_below.csh : Add time
	information along with the many backlog outputs this script takes. This helps
	understand how fast the backlog is/was clearing.