### PR TITLE
Fix v63003/gtm8735 subtest failure on systems where <realpath $ydb_dist> is different from $ydb_dist

### DIFF
--- a/64bittn/outref/read_only.txt
+++ b/64bittn/outref/read_only.txt
@@ -133,10 +133,10 @@ MUPIP SET -VERSION=V4 -reg DEFAULT
 %YDB-E-DBRDONLY, Database file ##TEST_PATH##/mumps.dat read only
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 ====== access_method =======
-%YDB-E-DBFILOPERR, Error doing database I/O to region mumps.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to database file mumps.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
-%YDB-E-DBFILOPERR, Error doing database I/O to region mumps.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to database file mumps.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 ==== REORG upgrade ====

--- a/com/inref.awk
+++ b/com/inref.awk
@@ -27,7 +27,7 @@ BEGIN {
 	env["gtm_tst"] = ENVIRON[ "gtm_tst" ]
 	env["in_test_path"]=env["gtm_tst"] "/" env["tst"]
 	env["gtm_exe"] = ENVIRON[ "gtm_exe" ]
-	env["gtm_exe_realpath"] = ENVIRON[ "gtm_exe_realpath" ]
+	"realpath $gtm_exe" |& getline env["gtm_exe_realpath"]
 	env["gtm_root"] = ENVIRON[ "gtm_root" ]
 	env["gtm_src"] = ENVIRON[ "gtm_src" ]
 	env["home"] = ENVIRON[ "HOME" ]

--- a/v63003/outref/gtm8735.txt
+++ b/v63003/outref/gtm8735.txt
@@ -33,7 +33,7 @@ Database file ##TEST_PATH##/mumps.dat now has BG access method
 # Displaying status of ##SOURCE_PATH##/dsehelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/dsehelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to database file ##SOURCE_REALPATH##/dsehelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
@@ -41,7 +41,7 @@ Database file ##TEST_PATH##/mumps.dat now has BG access method
 # Displaying status of ##SOURCE_PATH##/gdehelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/gdehelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to database file ##SOURCE_REALPATH##/gdehelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
@@ -49,7 +49,7 @@ Database file ##TEST_PATH##/mumps.dat now has BG access method
 # Displaying status of ##SOURCE_PATH##/gtmhelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/gtmhelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to database file ##SOURCE_REALPATH##/gtmhelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
@@ -57,7 +57,7 @@ Database file ##TEST_PATH##/mumps.dat now has BG access method
 # Displaying status of ##SOURCE_PATH##/lkehelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/lkehelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to database file ##SOURCE_REALPATH##/lkehelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
@@ -65,7 +65,7 @@ Database file ##TEST_PATH##/mumps.dat now has BG access method
 # Displaying status of ##SOURCE_PATH##/mupiphelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/mupiphelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to database file ##SOURCE_REALPATH##/mupiphelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database

--- a/v63003/outref/gtm8735.txt
+++ b/v63003/outref/gtm8735.txt
@@ -33,40 +33,40 @@ Database file ##TEST_PATH##/mumps.dat now has BG access method
 # Displaying status of ##SOURCE_PATH##/dsehelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_PATH##/dsehelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/dsehelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
-%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_PATH##/dsehelp.dat
+%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_REALPATH##/dsehelp.dat
 # Displaying status of ##SOURCE_PATH##/gdehelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_PATH##/gdehelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/gdehelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
-%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_PATH##/gdehelp.dat
+%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_REALPATH##/gdehelp.dat
 # Displaying status of ##SOURCE_PATH##/gtmhelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_PATH##/gtmhelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/gtmhelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
-%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_PATH##/gtmhelp.dat
+%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_REALPATH##/gtmhelp.dat
 # Displaying status of ##SOURCE_PATH##/lkehelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_PATH##/lkehelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/lkehelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
-%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_PATH##/lkehelp.dat
+%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_REALPATH##/lkehelp.dat
 # Displaying status of ##SOURCE_PATH##/mupiphelp.gld
   LOCK shares DB critical section     FALSE  Read Only                       ON
 # Attempting to change to no read only
-%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_PATH##/mupiphelp.dat
+%YDB-E-DBFILOPERR, Error doing database I/O to region ##SOURCE_REALPATH##/mupiphelp.dat
 %SYSTEM-E-ENO13, Permission denied
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 # Attempting to write to database
-%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_PATH##/mupiphelp.dat
+%YDB-E-DBPRIVERR, No privilege for attempted update operation for file: ##SOURCE_REALPATH##/mupiphelp.dat


### PR DESCRIPTION
We had a failure of the v63003/gtm8735 subtest on a host where $ydb_dist was
/usr/library/V999 but "realpath $ydb_dist" was "/extra/usr/library/V999". That is the
unexpanded and expanded file paths were different. This confused the test framework
when the test output had a mix of the unexpanded and expanded path names. The framework
only replaced the unexpanded pathname usages in the output that matched the environment
variable gtm_exe (which in turn matched the env var ydb_dist) with ##SOURCE_PATH##. For
the expanded pathname usages, it was expecting an env var gtm_exe_realpath to be set
coming in to the awk script. This was not being set in a YottaDB environment. So inref.awk
was enhanced to set this inside the awk script and replace these usages with ##SOURCE_REALPATH##.

With this framework level change, the v63003/gtm8735 subtest reference file was fixed to
use ##SOURCE_REALPATH## wherever it had the expanded path usages.