### PR TITLE
Fix V63004 GTM-8922 subtest failure on honey to avoid premature DB flush

### DIFF
--- a/v63004/u_inref/gtm8922.csh
+++ b/v63004/u_inref/gtm8922.csh
@@ -25,6 +25,8 @@ $MUPIP set -access_method=BG -file mumps.dat >>& dbcreate_log.txt
 $MUPIP set -access_method=BG -file a.dat >>& dbcreate_log.txt
 $MUPIP set -access_method=BG -file b.dat >>& dbcreate_log.txt
 
+$MUPIP set -file mumps.dat -flush_time=1:0:0 # Prevent interruptions from flush timers
+
 echo '# Run generalTest to test all commands of the form VIEW <KEYWORD>[:<region-list>]'
 echo '# and the VIEW POOLLIMIT:<region-list>:n[%] command'
 echo '# Tests for:'

--- a/v63004/u_inref/gtm8922.csh
+++ b/v63004/u_inref/gtm8922.csh
@@ -25,9 +25,7 @@ $MUPIP set -access_method=BG -file mumps.dat >>& dbcreate_log.txt
 $MUPIP set -access_method=BG -file a.dat >>& dbcreate_log.txt
 $MUPIP set -access_method=BG -file b.dat >>& dbcreate_log.txt
 
-$MUPIP set -file mumps.dat -flush_time=1:0:0 # Prevent interruptions from flush timers
-$MUPIP set -file a.dat -flush_time=1:0:0 # Prevent interruptions from flush timers
-$MUPIP set -file b.dat -flush_time=1:0:0 # Prevent interruptions from flush timers
+$MUPIP set -region "*" -flush_time=1:0:0 # Prevent interruptions from flush timers
 
 echo '# Run generalTest to test all commands of the form VIEW <KEYWORD>[:<region-list>]'
 echo '# and the VIEW POOLLIMIT:<region-list>:n[%] command'

--- a/v63004/u_inref/gtm8922.csh
+++ b/v63004/u_inref/gtm8922.csh
@@ -26,6 +26,8 @@ $MUPIP set -access_method=BG -file a.dat >>& dbcreate_log.txt
 $MUPIP set -access_method=BG -file b.dat >>& dbcreate_log.txt
 
 $MUPIP set -file mumps.dat -flush_time=1:0:0 # Prevent interruptions from flush timers
+$MUPIP set -file a.dat -flush_time=1:0:0 # Prevent interruptions from flush timers
+$MUPIP set -file b.dat -flush_time=1:0:0 # Prevent interruptions from flush timers
 
 echo '# Run generalTest to test all commands of the form VIEW <KEYWORD>[:<region-list>]'
 echo '# and the VIEW POOLLIMIT:<region-list>:n[%] command'


### PR DESCRIPTION
The Default regions n_dsk_write buffer had sometimes changed from 0 to 4 sooner than expected for tests on honey. These changes set the flush timer to an hour so that the test will no longer automatically write data to the disk. 