### PR TITLE
Fix occasional v63004/gtm8909 subtest failure due to extra MUPIP> or DSE> prompt

### DIFF
--- a/v63004/outref/gtm8909.txt
+++ b/v63004/outref/gtm8909.txt
@@ -8,10 +8,10 @@ LKE> help
 Additional information available: 
 Commands    Copyright   Introduction            Summary     
 Topic? #<Ctrl-C>
-# Exit LKE>
 Additional information available: 
 Commands    Copyright   Introduction            Summary     
 Topic? 
+# Exit LKE>
 LKE> exit
 > # Expect the shell prompt
 # Start DSE help facility
@@ -22,10 +22,10 @@ DSE> help
 Additional information available: 
 Commands    Copyright   Operations  Summary     
 Topic? #<Ctrl-C>
-# Exit DSE>
 Additional information available: 
 Commands    Copyright   Operations  Summary     
 Topic? 
+# Exit DSE>
 DSE> exit
 > # Expect the shell prompt
 # Start MUPIP help facility
@@ -35,11 +35,11 @@ Additional information available:
 Copyright   GDM         Introduction            Journaling  Replication
 Summary     
 Topic? #<Ctrl-C>
-# Exit MUPIP>
 Additional information available: 
 Copyright   GDM         Introduction            Journaling  Replication
 Summary     
 Topic? 
+# Exit MUPIP>
 MUPIP> # Expect the shell prompt
 exit
 > 

--- a/v63004/u_inref/gtm8909.exp
+++ b/v63004/u_inref/gtm8909.exp
@@ -41,9 +41,10 @@ foreach prompt $promptList {
 	send -- "help\r"
 	expect  "Topic?"
 	puts "#<Ctrl-C>"
-	send -- "\x03\r"
+	send -- "\x03"
+	expect  "Topic?"
 	send -- "\r"
-	puts "# Exit $prompt>"
+	puts "\n# Exit $prompt>"
 	expect -exact "$prompt>"
 	send -- "exit\r"
 	}


### PR DESCRIPTION
We had two failures till now on slower systems (armv6l) and each time it was
an extra MUPIP> or DSE> prompt.

We are sending two \r in the expect script. Not sure why that is necessary.
That is the cause of the extra MUPIP> or DSE> prompt.

Have therefore reworked the test to do a better job with just one \r.
Have run this test on all boxes (x86_64, armv7l and armv6l) 10 times and it passes fine.