### PR TITLE
V63004 GTM-5730 Fix

### DIFF
--- a/v63004/u_inref/gtm5730.csh
+++ b/v63004/u_inref/gtm5730.csh
@@ -17,7 +17,6 @@ if ($status) then
 	echo "DB Create Failed, Output Below"
 	cat dbcreate.outx
 endif
-echo ''
 
 echo "# Get start time (used in .updproc file name)"
 setenv start_time `cat start_time` # start_time is used in naming conventions
@@ -39,5 +38,4 @@ if ($status) then
 	echo "DB Check Failed, Output Below"
 	cat dbcheck.outx
 endif
-echo ''
 


### PR DESCRIPTION
Remove echo '' statements unintentionally added to gtm5730.csh along with dbcreate/dbcheck error check

These echo ' ' statemets were responsible for the blank lines added to the top and bottom of the gtm5730.log files. I'm unsure of how I missed this, but the echo ' ' commands and the blank lines in the log file have been removed. 