### PR TITLE
Fix very rare ideminter_rolrec/interrupted_rollback_or_recover subtest failure due to a timing issue

### DIFF
--- a/com/mu_reorg_upgrd_dwngrd_crash.csh
+++ b/com/mu_reorg_upgrd_dwngrd_crash.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2005-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -32,7 +35,7 @@ ps_mrc >>& $KILL_LOG
 
 @ maxtry = 10
 @ tried = 0
-set wait_time = 60			# Try for a maximum of 60 seconds
+set wait_time = 300			# Try for a maximum of 5 minutes
 set now_time = `date +%s`
 @ max_wait = $now_time + $wait_time
 while ($now_time <= $max_wait)
@@ -41,9 +44,9 @@ while ($now_time <= $max_wait)
 	# PID for MUPIP REORG
 	set ppid=`$grep PID mu_reorg_upgrd_dwngrd.pid | $tst_awk '{printf("%s ",$2);}'`
 	echo "The ppid is $ppid" >> $KILL_LOG
-	echo "------------------" >>! ${KILL_LOG}_ps
+	echo "------------------ time $now_time --------------" >>! ${KILL_LOG}
 	date >>& $KILL_LOG
-	set rpid=`ps_mrc | $grep "mupip" | tee -a ${KILL_LOG}_ps | $tst_awk '{if ($3 == '$ppid') printf($2);}'`
+	set rpid=`ps_mrc | $grep "mupip" | tee -a ${KILL_LOG} | $tst_awk '{if ($3 == '$ppid') printf($2);}'`
 	if ( "" == "$rpid") then
 		set flag = "notfound"
 		echo "TEST-I-MUPIP_CRASH Not found, will look again..." >> $KILL_LOG


### PR DESCRIPTION
We had an in-house test failure with the following diff
```
./ideminter_rolrec_0_5/interrupted_rollback_or_recover/close_reorg_upgrd_dwngrd.out
TEST-E-MUPIP is not executing!
```
In this case, the com/mu_reorg_upgrd_dwngrd_crash.csh script waits for 60 seconds,
checking every 1 second if the mupip reorg process can be found. And it found that
process in the 60th (last) iteration and was able to kill it but still ended up issuing
the TEST-E-MUPIP error. Therefore, the timeout is now increased to 300 seconds.

This opportunity is used to further enhance logging in the script. Having the output of
multiple lines in a script go to different log files (${KILL_LOG} and ${KILL_LOG}_ps)
makes it very hard to analyze. Also record the time as part of every ps output.