### PR TITLE
Fix v63003/gtm8779 subtest failure due to DBFREEZEON/DBFREEZEOFF messages from other concurrently running tests

### DIFF
--- a/v63003/outref/gtm8779.txt
+++ b/v63003/outref/gtm8779.txt
@@ -7,7 +7,7 @@ All requested regions unfrozen
 Region BREG is now FROZEN
 All requested regions frozen
 # Verifying System received a DBFREEZEON message for only BREG
-%YDB-I-DBFREEZEON, Region BREG is FROZEN
+%YDB-I-DBFREEZEON, Database file ##TEST_PATH##/b.dat is FROZEN
 
 # Turning on Freeze for all
 All requested regions frozen
@@ -15,8 +15,8 @@ Region AREG is now FROZEN
 Region BREG is now FROZEN
 Region DEFAULT is now FROZEN
 # Verifying System received a DBFREEZEON message for only DEFAULT and AREG
-%YDB-I-DBFREEZEON, Region AREG is FROZEN
-%YDB-I-DBFREEZEON, Region DEFAULT is FROZEN
+%YDB-I-DBFREEZEON, Database file ##TEST_PATH##/a.dat is FROZEN
+%YDB-I-DBFREEZEON, Database file ##TEST_PATH##/mumps.dat is FROZEN
 
 # Resetting DEFAULT and AREG to OFF, BREG to ON
 Region DEFAULT is now UNFROZEN
@@ -26,8 +26,8 @@ All requested regions unfrozen
 Region BREG is now FROZEN
 All requested regions frozen
 # Verifying System received a DBFREEZEOFF message for only AREG and DEFAULT
-%YDB-I-DBFREEZEOFF, Region DEFAULT is UNFROZEN
-%YDB-I-DBFREEZEOFF, Region AREG is UNFROZEN
+%YDB-I-DBFREEZEOFF, Database file ##TEST_PATH##/mumps.dat is UNFROZEN
+%YDB-I-DBFREEZEOFF, Database file ##TEST_PATH##/a.dat is UNFROZEN
 
 # Turning off Freeze for all
 All requested regions unfrozen
@@ -35,4 +35,4 @@ Region AREG is now UNFROZEN
 Region BREG is now UNFROZEN
 Region DEFAULT is now UNFROZEN
 # Verifying System received a DBFREEZEOFF message for only BREG
-%YDB-I-DBFREEZEOFF, Region BREG is UNFROZEN
+%YDB-I-DBFREEZEOFF, Database file ##TEST_PATH##/b.dat is UNFROZEN

--- a/v63003/u_inref/gtm8779.csh
+++ b/v63003/u_inref/gtm8779.csh
@@ -35,7 +35,7 @@ $ydb_dist/mumps -run gtm8779 >>& temp0.out
 set s0 = `cat temp0.out`
 echo "# Verifying System received a DBFREEZEON message for only BREG"
 $gtm_tst/com/getoper.csh "$t0" "" t0t1.txt "" $s0
-cat t0t1.txt |& $grep DBFREEZE |& $tst_awk '{print $6 " " $7 " " $8 " " $9 " " $10}'
+cat t0t1.txt |& $grep "DBFREEZE.*$PWD" |& $tst_awk '{print $6,$7,$8,$9,$10,$11}'
 
 
 # To ensure our previous freeze settings are not captured in getoper
@@ -53,7 +53,7 @@ $ydb_dist/mumps -run gtm8779 >>& temp1.out
 set s1 = `cat temp1.out`
 echo "# Verifying System received a DBFREEZEON message for only DEFAULT and AREG"
 $gtm_tst/com/getoper.csh "$t1" "" t1t2.txt "" $s1
-cat t1t2.txt |& $grep DBFREEZE |& $tst_awk '{print $6 " " $7 " " $8 " " $9 " " $10}' |& sort
+cat t1t2.txt |& $grep "DBFREEZE.*$PWD" |& $tst_awk '{print $6,$7,$8,$9,$10,$11}' |& sort
 
 
 # To ensure our previous freeze settings are not captured in getoper
@@ -73,7 +73,7 @@ $ydb_dist/mumps -run gtm8779 >>& temp2.out
 set s2 = `cat temp2.out`
 echo "# Verifying System received a DBFREEZEOFF message for only AREG and DEFAULT"
 $gtm_tst/com/getoper.csh "$t2" "" t2t3.txt "" $s2
-cat t2t3.txt |& $grep DBFREEZE |& $tst_awk '{print $6 " " $7 " " $8 " " $9 " " $10}'
+cat t2t3.txt |& $grep "DBFREEZE.*$PWD" |& $tst_awk '{print $6,$7,$8,$9,$10,$11}'
 
 
 # To ensure our previous freeze settings are not captured in getoper
@@ -90,7 +90,7 @@ $ydb_dist/mumps -run gtm8779 >>& temp3.out
 set s3 = `cat temp3.out`
 echo "# Verifying System received a DBFREEZEOFF message for only BREG"
 $gtm_tst/com/getoper.csh "$t3" "" t3t4.txt "" $s3
-cat t3t4.txt |& $grep DBFREEZE |& $tst_awk '{print $6 " " $7 " " $8 " " $9 " " $10}'
+cat t3t4.txt |& $grep "DBFREEZE.*$PWD" |& $tst_awk '{print $6,$7,$8,$9,$10,$11}'
 
 $gtm_tst/com/dbcheck.csh >>& check.out
 if ($status) then


### PR DESCRIPTION
Since the DBFREEZEON/DBFREEZEOFF messages used to print only the region name, it was possible for such messages from concurrently running tests (which most likely have the same region names as the v63003/gtm8779 subtest) to also be found and can confuse the gtm8779 test. Due to the code change at YottaDB/YottaDB#273, the DBFREEZEON/DBFREEZEOFF messages now print the full path of the database file name corresponding to the region. Therefore, we can now search for the current test output directory ($PWD) to filter out only those messages corresponding to our running test and therefore avoid false failures.