### PR TITLE
Fix suppl_inst_A_1/instinfoprop subtest due to lack of space in /tmp for temporary files created by <sort>

### DIFF
--- a/com/mupip_rollback.csh
+++ b/com/mupip_rollback.csh
@@ -576,9 +576,9 @@ if (! $forward_only_specified) then
 		endif
 		if ($do_fetchresync) then
 			$tst_awk '{if (NR == 1) print $1,$2,"SECONDARY"'$dispstr'; else print; }' $back_losttn_file	\
-									| sort >& $back_losttn_file.sort
+									| $sort >& $back_losttn_file.sort
 		else
-			$tst_awk '{if (NR == 1) print $1,$2,$3'$dispstr'; else print; }' $back_losttn_file | sort >& $back_losttn_file.sort
+			$tst_awk '{if (NR == 1) print $1,$2,$3'$dispstr'; else print; }' $back_losttn_file | $sort >& $back_losttn_file.sort
 		endif
 		$sort $forw_losttn_file >& $forw_losttn_file.sort
 		echo "cmp $back_losttn_file.sort $forw_losttn_file.sort" >>& $misclog


### PR DESCRIPTION
A prior commit (SHA 3c5e37562cad7482a438aaad3c006336ed713c08) fixed sort usages to be $sort
where the $sort variable value was "sort -T" to redirect the temporary file directory to be
the test output directory (instead of /tmp).

But it missed out a couple of sort usages which were at the end of a long line. And we had
a test failure due to one such sort in an internal test. Those couple usages are now fixed.