### PR TITLE
Fixed test failures for v63003/gtm8839

### DIFF
--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -59,6 +59,10 @@ endif
 
 # Use $subtest_exclude_list to remove subtests that are to be disabled on a particular host or OS
 setenv subtest_exclude_list	""
+# Filter out white box tests that cannot run in pro
+if ("pro" == "$tst_image") then
+	setenv subtest_exclude_list "$subtest_exclude_list gtm8839"
+endif
 
 # Submit the list of subtests
 $gtm_tst/com/submit_subtest.csh

--- a/v63003/outref/outref.txt
+++ b/v63003/outref/outref.txt
@@ -20,7 +20,9 @@ PASS from gtm8856
 PASS from gtm8857
 PASS from gtm8854
 PASS from gtm8795
+##SUSPEND_OUTPUT PRO
 PASS from gtm8839
+##ALLOW_OUTPUT PRO
 PASS from gtm8781
 PASS from gtm8849
 PASS from gtm8794


### PR DESCRIPTION
Suspends output in pro version to account for white box case