### PR TITLE
Fix occasional v62000/gtm7919 subtest failure due to getoper.csh usage not capturing all syslog messages till then

### DIFF
--- a/v62000/u_inref/gtm7919.csh
+++ b/v62000/u_inref/gtm7919.csh
@@ -54,18 +54,16 @@ while ($i <= $num_of_cases)
 	# Generate messages in the terminal or syslog.
 	set time_before = `date +"%b %e %H:%M:%S"`
 	$gtm_dist/mumps -run genmsgs ${msgFileName} ${argsFileName}.cmp ${pidFileName}.log >&! ${logFileName}.outx
-	set time_after = `date +"%b %e %H:%M:%S"`
 
 	if ($setWhiteBoxTest) then
 		# Get the pid of the message-issuing MUMPS process and the mnemonic of the last message.
 		set pid = `cat ${pidFileName}.log`
-		set last_mnemonic = `cat ${logFileName}.outx`
 
 		# Save the output of gensmgs run in a separate file in case of errors.
 		mv ${logFileName}.outx ${logFileName}.outx.orig
 
 		# Save the generated syslog messages in a local file.
-		$gtm_tst/com/getoper.csh "$time_before" "$time_after" ${logFileName}.outx.tmp "" "${last_mnemonic}"
+		$gtm_tst/com/getoper.csh "$time_before" "" ${logFileName}.outx.tmp
 
 		# Grep out only the messages that originated from our process.
 		$grep "\[$pid\]" ${logFileName}.outx.tmp > ${logFileName}.outx


### PR DESCRIPTION
getoper.csh captures all messages since a particular time until the instant the getoper.csh
script is called correctly if the "" parameter is passed as $2 ($time_after). It does this
by internally generating a random string and sending it to the syslog and waiting for that
to show up in the syslog at which point it is guaranteed all pending syslog messages till
then will show up in the syslog before the random string.

The alternative usage of supplying a non-null $2 ($time_after) is that we might miss out
on syslog messages that are asynchronously being delivered but not yet recorded in the
journalctl logs. This is the current usage and could cause occasional failures.