### PR TITLE
Fix set_jnl_1/autoswitchtp subtest failure due to update process being killed by OOM killer

### DIFF
--- a/set_jnl/u_inref/autoswitchtp.csh
+++ b/set_jnl/u_inref/autoswitchtp.csh
@@ -29,7 +29,7 @@ echo "setenv test_align $force_align_size"							>> settings.csh
 # YDB-E-JNLTRANS2BIG, Transaction needs an estimated [xxx blocks]...which exceeds the AUTOSWITCHLIMIT of yyy blocks
 setenv gtm_test_spanreg 0	# Spanningregions cause imbalance and JNLTRANS2BIG error
 
-$gtm_tst/com/dbcreate.csh mumps 9 125 3500 4096 5000 8192 5000
+$gtm_tst/com/dbcreate.csh mumps 9 125 3500 4096 5000 1024 5000
 #
 # Note : The "-journal=enable,on,before" usage below should normally be replaced with $tst_jnl_str. This will make sure we use
 # BEFORE_IMAGE or NOBEFORE_IMAGE depending on what was specified at the test startup. But in the case the test was started with


### PR DESCRIPTION
The update process was killed by the OOM (out-of-memory) killer on a 1-CPU machine with just
512Mb total memory. This caused the test to hang/fail.

This test creates 9 regions each with 8K global buffers and 4K blocksize. That itself accounts
for a total of at least 288Mb memory. And jnlpool/recvpool etc. will take the total to > 300Mb.

To reduce the memory requirements of the update process, the dbcreate now sets the global
buffers to 1K instead of 8K. This should reduce the total memory to < 100Mb which should
hopefully avoid the OOM killer from kicking in.