### PR TITLE
Enhance dbcreate/dbcheck to work with subdirectories holding .gld/.dat files

### DIFF
--- a/com/dbcheck_base.csh
+++ b/com/dbcheck_base.csh
@@ -40,6 +40,15 @@ else
 endif
 
 set arg1 = "$1"
+if (-e "${arg1}.gld") then
+	set dir = `dirname ${arg1}.gld`
+	cd $dir
+	# Keep setting gtmgbldir env var (not ydb_gbldir) in this test framework script
+	# so we can run tests with older GT.M versions that don't understand ydb_gbldir.
+	setenv gtmgbldir `basename ${arg1}.gld`
+	shift
+	set arg1 = "$1"
+endif
 
 if (!($?acc_meth)) setenv acc_meth "BG"
 if (!($?GDE))  then
@@ -118,7 +127,11 @@ else
 	if (! $noleftoveripccheck_specified) then
 		source $gtm_tst/com/leftover_ipc_cleanup_if_needed.csh $0 # do rundown if needed before requiring standalone access
 	endif
-	setenv dbname mumps
+	setenv dbname $arg1
+	if ($gtmgbldir != "mumps.gld") then
+		# Doing dbcheck on gbldir that is not mumps.gld. Display the actual gtmgbldir for this non-default scenario.
+		echo -n "gbldir = $gtmgbldir; "
+	endif
 	echo "$MUPIP integ -REG *"
 	$MUPIP integ -REG $online_noonline "*" >& tmp.mupip
 	# If gtm_test_trig_upgrade env var is defined, the parent test uses triggers and wants to additionally

--- a/com/dbcheck_base.csh
+++ b/com/dbcheck_base.csh
@@ -42,12 +42,15 @@ endif
 set arg1 = "$1"
 if (-e "${arg1}.gld") then
 	set dir = `dirname ${arg1}.gld`
-	cd $dir
-	# Keep setting gtmgbldir env var (not ydb_gbldir) in this test framework script
-	# so we can run tests with older GT.M versions that don't understand ydb_gbldir.
-	setenv gtmgbldir `basename ${arg1}.gld`
-	shift
-	set arg1 = "$1"
+	if ("$dir" != ".") then
+		# A subdirectory has been specified. If so go into that subdirectory and do MUPIP INTEG -REG "*"
+		cd $dir
+		# Set gtmgbldir env var (not ydb_gbldir) in this test framework script
+		# so we can run tests with older GT.M versions that don't understand ydb_gbldir.
+		setenv gtmgbldir `basename ${arg1}.gld`
+		shift
+		set arg1 = "$1"
+	endif
 endif
 
 if (!($?acc_meth)) setenv acc_meth "BG"

--- a/com/dbcheck_base.csh
+++ b/com/dbcheck_base.csh
@@ -128,10 +128,6 @@ else
 		source $gtm_tst/com/leftover_ipc_cleanup_if_needed.csh $0 # do rundown if needed before requiring standalone access
 	endif
 	setenv dbname $arg1
-	if ($gtmgbldir != "mumps.gld") then
-		# Doing dbcheck on gbldir that is not mumps.gld. Display the actual gtmgbldir for this non-default scenario.
-		echo -n "gbldir = $gtmgbldir; "
-	endif
 	echo "$MUPIP integ -REG *"
 	$MUPIP integ -REG $online_noonline "*" >& tmp.mupip
 	# If gtm_test_trig_upgrade env var is defined, the parent test uses triggers and wants to additionally

--- a/com/dbcreate_multi.awk
+++ b/com/dbcreate_multi.awk
@@ -103,7 +103,7 @@ END {
       if (value["file_name"] !~/..*/ || value["file_name"] ~/\./) value["file_name"]=default_filename
       # Check if value["file_name"] points to a subdirectory. If so, cd to that subdir before creating the db
       nsubdirs = split(value["file_name"], fullpath, "/")
-      if (1 < nsubdirs)
+      if ((1 < nsubdirs) && ("" != fullpath[1]))	# fullpath[1] check needed to ensure it is not an absolute path
       {
 	      subdir = ""
 	      for (i = 1; i < nsubdirs; i++)

--- a/com/dbcreate_multi.awk
+++ b/com/dbcreate_multi.awk
@@ -3,7 +3,7 @@
 # Copyright (c) 2002-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -101,6 +101,17 @@ END {
       sub("\\.gld$","",value["filename_override"])
       if (value["filename_override"]!="") default_filename=value["filename_override"]
       if (value["file_name"] !~/..*/ || value["file_name"] ~/\./) value["file_name"]=default_filename
+      # Check if value["file_name"] points to a subdirectory. If so, cd to that subdir before creating the db
+      nsubdirs = split(value["file_name"], fullpath, "/")
+      if (1 < nsubdirs)
+      {
+	      subdir = ""
+	      for (i = 1; i < nsubdirs; i++)
+		subdir = subdir "" fullpath[i] "/"
+	      printf "mkdir -p %s\n", subdir
+	      printf "cd %s\n", subdir
+	      value["file_name"] = fullpath[nsubdirs]
+      }
       print "setenv dbname " value["file_name"]
       print "setenv gtmgbldir \"$dbname.gld\""
       print "set timenow = `date +%H_%M_%S`"


### PR DESCRIPTION
dbcreate.csh currently only creates gld and db files in the local and remote sides of the
test output directory. It does not let the user create the gld/db in a subdirectory on the
local/remote side of the test. That need is now implemented in dbcreate and dbcheck.

The syntax currently to create a mumps.gld and mumps.dat/a.dat
```
	dbcreate.csh mumps 2
```

The new syntax to create a mumps.gld and mumps.dat/a.dat under the dir1 directory is
```
	dbcreate.csh dir1/mumps 2
```

i.e. instead of "mumps", one needs to specify "dir1/mumps".

Similarly, the syntax currently to check the mumps.dat/a.dat db is
```
	dbcheck.csh
```

The new syntax to dbcheck mumps.dat/a.dat under the dir1 subdirectory is
```
	dbcheck.csh dir1/mumps
```

The new syntax causes both dbcreate and dbcheck to go into dir1 and see if a mumps.gld file
exists (because dir1/mumps was specified) and if so it will use that as gtmgbldir/ydb_gbldir
and do the mupip create or mupip integ -reg "*" respectively.