### PR TITLE
Fix occasional v63003/gtm8850 test failure on slow systems

### DIFF
--- a/v63003/u_inref/gtm8850freeze.csh
+++ b/v63003/u_inref/gtm8850freeze.csh
@@ -13,7 +13,6 @@
 #
 # Helper script for gtm885, turns freeze on and off until signalled to stop
 #
-rm -f test.STOP
 while (1)
 	set rand = `$gtm_tst/com/genrandnumbers.csh 1 0 1`
 	echo $rand
@@ -27,6 +26,7 @@ while (1)
         sleep 1
         $ydb_dist/mupip freeze -off "*"
         if (-e test.STOP) then
+		# foreground script gtm8850.csh has signaled us to STOP.
                 break
         endif
 end

--- a/v63003/u_inref/gtm8850xcmd.csh
+++ b/v63003/u_inref/gtm8850xcmd.csh
@@ -11,12 +11,13 @@
 #								#
 #################################################################
 #
-# Helper script for gtm8850, executes a command in mumps to verify
-# it is quitting out appropriately
+# Helper script for gtm8850, starts mumps, does a couple updates and halts in a loop to verify
+# it halts without hanging while an online freeze on/off command is concurrently running.
 #
 while (1)
         $ydb_dist/mumps -run ^%XCMD 'set ^x($j)=$j kill ^x($j)'
         if (-e test.STOP) then
+		# foreground script gtm8850.csh has signaled us to STOP.
                 break
         endif
 end


### PR DESCRIPTION
gtm8850.csh creates the file test.STOP after launching the background script
gtm8850freeze.csh and waiting 15 seconds. gtm8850freeze.csh deletes test.STOP
as the first step. It is possible on a really slow system that gtm8850.csh is
done waiting 15 seconds and has created the file test.STOP but gtm8850freeze.csh
has not yet finished executing the first line (rm -f test.STOP). In that case,
the file test.STOP is never seen by the background scripts gtm8850freeze.csh and
gtm8850xcmd.csh which means the test never finishes. This timing issue is now
addressed by removing the unnecessary rm -f test.STOP.

While at this, enhanced comments a bit in the background scripts.