### PR TITLE
Make r120/gctest subtest failure output more user-friendly

### DIFF
--- a/r120/inref/gctest.m
+++ b/r120/inref/gctest.m
@@ -56,8 +56,12 @@ done    if '$zeof write $zstatus,!
         close file
 	set errcnt=0
 	set i=i-1
+	set allowedscale=3 ; see comments in r120/u_inref/gctest.csh about allowing 3x increase every iteration
 	for j=1:1:i-1  do
-	. set max=cpu(j)*3
-	. if cpu(j+1)>max write "TEST-E-FAIL : ",! zshow "v"  if $incr(errcnt)
+	. set actualscale=(cpu(j+1)/cpu(j))*100\1/100
+	. if actualscale>allowedscale do
+	. . write "TEST-E-FAIL : cpu(",j+1,")=",cpu(j+1)," is ",actualscale,"x times cpu(",j,")=",cpu(j)," but max allowed is ",allowedscale,"x",!
+	. . if $incr(errcnt)
 	if errcnt=0 write "TEST-E-PASS",!
+	else        write !,"ZSHOW ""V"" output follows",! zshow "v"
         quit


### PR DESCRIPTION
The r120/gctest fails rarely due to some other system load.
If a test fails, the failure diff currently is not user friendly.
This commit makes it user friendly.

Example new output is the following in case the test fails

TEST-E-FAIL : cpu(3)=0.610 is 3.17x times cpu(2)=0.192 but max allowed is 3x
TEST-E-FAIL : cpu(4)=1.989 is 3.26x times cpu(3)=0.610 but max allowed is 3x

Previously there used to be a dump of all M local variables and one has to read
through gctest.m to figure out why the test failed.