### PR TITLE
 New v63003/gtm8844 subtest (Tests GTM-8844 in V63003)

### DIFF
--- a/v63003/inref/gtm8844.m
+++ b/v63003/inref/gtm8844.m
@@ -12,14 +12,20 @@
 ;
 haltfn
 	set $etrap="do incrtrap^incrtrap"
+	write "# Halt 1, Expect a RESTRICTEDOP error",!
 	halt
+	write "# Halt 2, Expect a RESTRICTEDOP fatal error",!
 	halt
+	write "Haltfn failed"
 	quit
 
 zhaltfn
 	set $etrap="do incrtrap^incrtrap"
+	write "# Zhalt 1, Expect a RESTRICTEDOP error",!
 	zhalt
+	write "# Zhalt 2, Expect a RESTRICTEDOP fatal error",!
 	zhalt
+	write "Zhaltfn failed"
 	quit
 
 zgotofn
@@ -29,3 +35,4 @@ zgotofn
 	write "$ECODE=",$ECODE,!
 	zgoto 0
 	quit
+

--- a/v63003/inref/gtm8844.m
+++ b/v63003/inref/gtm8844.m
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+haltfn
+	set $etrap="do incrtrap^incrtrap"
+	halt
+	halt
+	quit
+
+zhaltfn
+	set $etrap="do incrtrap^incrtrap"
+	zhalt
+	zhalt
+	quit
+
+zgotofn
+	set $etrap="do incrtrap^incrtrap"
+	zhalt
+	write "$ZTRAP=",$ZTRAP,!
+	write "$ECODE=",$ECODE,!
+	zgoto 0
+	quit

--- a/v63003/inref/gtm8844.m
+++ b/v63003/inref/gtm8844.m
@@ -14,7 +14,8 @@ haltfn
 	set $etrap="do incrtrap^incrtrap"
 	write "# Halt 1, Expect a RESTRICTEDOP error",!
 	halt
-	write "# Halt 2, Expect a RESTRICTEDOP fatal error",!
+	hang:$ZTRNLNM("pause") 1
+	write "# Halt 2",!
 	halt
 	write "Haltfn failed"
 	quit
@@ -23,10 +24,12 @@ zhaltfn
 	set $etrap="do incrtrap^incrtrap"
 	write "# Zhalt 1, Expect a RESTRICTEDOP error",!
 	zhalt
-	write "# Zhalt 2, Expect a RESTRICTEDOP fatal error",!
+	hang:$ZTRNLNM("pause") 1
+	write "# Zhalt 2",!
 	zhalt
 	write "Zhaltfn failed"
 	quit
+
 
 zgotofn
 	set $etrap="do incrtrap^incrtrap"

--- a/v63003/inref/gtm8844.m
+++ b/v63003/inref/gtm8844.m
@@ -11,23 +11,23 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
 haltfn
-	set $etrap="do incrtrap^incrtrap"
+	set $ztrap="goto incrtrap^incrtrap"
 	write "# Halt 1, Expect a RESTRICTEDOP error",!
 	halt
 	hang:$ZTRNLNM("pause") .5
 	write "# Halt 2",!
 	halt
-	write "Haltfn failed",!
+	hang 1
 	quit
 
 zhaltfn
-	set $etrap="do incrtrap^incrtrap"
+	set $ztrap="goto incrtrap^incrtrap"
 	write "# Zhalt 1, Expect a RESTRICTEDOP error",!
 	zhalt
 	hang:$ZTRNLNM("pause") .5
 	write "# Zhalt 2",!
 	zhalt
-	write "Zhaltfn failed",!
+	hang 1
 	quit
 
 

--- a/v63003/inref/gtm8844.m
+++ b/v63003/inref/gtm8844.m
@@ -36,3 +36,14 @@ zgotofn
 	zgoto 0
 	quit
 
+triggerfnx
+	if ($view("ENVIRONMENT")'["MUMPS")&(^H=0) do
+	. zhalt
+	quit
+
+triggerfny
+	if ($view("ENVIRONMENT")'["MUMPS")&(^H=0)  do
+	. halt
+	quit
+
+

--- a/v63003/inref/gtm8844.m
+++ b/v63003/inref/gtm8844.m
@@ -15,8 +15,11 @@ haltfn
 	write "# Halt 1, Expect a RESTRICTEDOP error",!
 	halt
 	hang:$ZTRNLNM("pause") .5
-	write "# Halt 2",!
+	write "# Halt 2, Expect a "
+	write:'$ZTRNLNM("pause") "fatal "
+	write "RESTRICTEDOP error",!
 	halt
+	; Needed so the second halt and quit don't produce a RESTRICTEDOP error
 	hang 1
 	quit
 
@@ -25,8 +28,11 @@ zhaltfn
 	write "# Zhalt 1, Expect a RESTRICTEDOP error",!
 	zhalt
 	hang:$ZTRNLNM("pause") .5
-	write "# Zhalt 2",!
+	write "# Zhalt 2, Expect a "
+	write:'$ZTRNLNM("pause") "fatal "
+	write "RESTRICTEDOP error",!
 	zhalt
+	; needed so the second zhalt and quit don't produce a RESTRICTEDOP error
 	hang 1
 	quit
 

--- a/v63003/inref/gtm8844.m
+++ b/v63003/inref/gtm8844.m
@@ -14,20 +14,20 @@ haltfn
 	set $etrap="do incrtrap^incrtrap"
 	write "# Halt 1, Expect a RESTRICTEDOP error",!
 	halt
-	hang:$ZTRNLNM("pause") 1
+	hang:$ZTRNLNM("pause") .5
 	write "# Halt 2",!
 	halt
-	write "Haltfn failed"
+	write "Haltfn failed",!
 	quit
 
 zhaltfn
 	set $etrap="do incrtrap^incrtrap"
 	write "# Zhalt 1, Expect a RESTRICTEDOP error",!
 	zhalt
-	hang:$ZTRNLNM("pause") 1
+	hang:$ZTRNLNM("pause") .5
 	write "# Zhalt 2",!
 	zhalt
-	write "Zhaltfn failed"
+	write "Zhaltfn failed",!
 	quit
 
 

--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -47,6 +47,7 @@
 # gtm8801	    [vinay] Tests ^%YGBLSTAT works on a cmake build
 # gtm8842	    [vinay] Tests TRIGGER_MOD appropriately restricts ZBREAK and ZSTEP
 # gtm8858	    [vinay] Demonstrates the improved available information in cases of apparent database integrity issues
+# gtm8844	    [vinay] Tests the functionality of HALT and ZHALT in trigger logic and when restricted
 #-------------------------------------------------------------------------------------
 
 echo "v63003 test starts..."
@@ -57,7 +58,8 @@ setenv subtest_list_non_replic "gtm8788 gtm7986 gtm8186 gtm8804 gtm8832 gtm8617 
 setenv subtest_list_non_replic "$subtest_list_non_replic gtm8846 gtm8780 gtm8787 gtm8889 gtm8856 gtm8857 gtm8854 gtm8795 gtm8839"
 setenv subtest_list_non_replic "$subtest_list_non_replic gtm8781 gtm8849 gtm8794 gtm8790 gtm8587 gtm8855 gtm8850 gtm8847 gtm8801"
 setenv subtest_list_non_replic "$subtest_list_non_replic gtm8842 gtm8858"
-setenv subtest_list_replic     "gtm8732r gtm8795 gtm8794 gtm8850"
+setenv subtest_list_replic     "gtm8732r gtm8795 gtm8794 gtm8850 gtm8844"
+
 
 if ($?test_replic == 1) then
 	setenv subtest_list "$subtest_list_common $subtest_list_replic"

--- a/v63003/outref/gtm8844.txt
+++ b/v63003/outref/gtm8844.txt
@@ -3,37 +3,36 @@
 # Two consecutive halts
 # Halt 1, Expect a RESTRICTEDOP error
 ZSTATUS=haltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
-# Halt 2
+# Halt 2, Expect a fatal RESTRICTEDOP error
 %YDB-F-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
 ##TEST_AWKYDB_FATAL_ERROR.ZSHOW_DMP_[0-9]*_1.txt
 # -------------------------------------------------------------------------------------------
 # Two consecutive zhalts
 # Zhalt 1, Expect a RESTRICTEDOP error
 ZSTATUS=zhaltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
-# Zhalt 2
+# Zhalt 2, Expect a fatal RESTRICTEDOP error
 %YDB-F-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
 ##TEST_AWKYDB_FATAL_ERROR.ZSHOW_DMP_[0-9]*_1.txt
 # -------------------------------------------------------------------------------------------
 # Two consecutive halts with a pause
 # Halt 1, Expect a RESTRICTEDOP error
 ZSTATUS=haltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
-# Halt 2
-ZSTATUS=haltfn+6^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
+# Halt 2, Expect a RESTRICTEDOP error
+ZSTATUS=haltfn+8^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
 ls: No match.
 # -------------------------------------------------------------------------------------------
 # Two consecutive zhalts with a pause
 # Zhalt 1, Expect a RESTRICTEDOP error
 ZSTATUS=zhaltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
-# Zhalt 2
-ZSTATUS=zhaltfn+6^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
+# Zhalt 2, Expect a RESTRICTEDOP error
+ZSTATUS=zhaltfn+8^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
 ls: No match.
 # -------------------------------------------------------------------------------------------
 # Confirming ZHALT,ZGOTO 0 produces an error in the shell
 ZSTATUS=zgotofn+2^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
 $ZTRAP=
 $ECODE=,Z150384210,
-Status After ZGOTOFN=82
-Error Detected
+$Status in Shell After ZGOTOFN=82
 # -------------------------------------------------------------------------------------------
 ==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "set ^X=0  set ^Y=0"'==
 File trigger.txt, Line 1: Added SET trigger on ^X named triggerx
@@ -58,7 +57,7 @@ File trigger.txt, Line 2: Added SET trigger on ^Y named triggery
 ==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth >& checkhealth.tmp ; cat checkhealth.tmp'==
 PID ##FILTERED##[##PID##] Receiver server is alive
 ##TEST_AWKPID [0-9]* Update process is NOT alive
-# Restore the update process
+# Restart the update process
 # Confirm secondary's update process is restored and database is up to date
 ==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth'==
 PID ##FILTERED##[##PID##] Receiver server is alive
@@ -77,7 +76,7 @@ PID ##FILTERED##[##PID##] Update process is alive
 ==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth >& checkhealth.tmp ; cat checkhealth.tmp'==
 PID ##FILTERED##[##PID##] Receiver server is alive
 ##TEST_AWKPID [0-9]* Update process is NOT alive
-# Restore the update process
+# Restart the update process
 # Confirm secondary's update process is restored and database is up to date
 ==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth'==
 PID ##FILTERED##[##PID##] Receiver server is alive

--- a/v63003/outref/gtm8844.txt
+++ b/v63003/outref/gtm8844.txt
@@ -18,12 +18,14 @@ ZSTATUS=zhaltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted o
 # Halt 1, Expect a RESTRICTEDOP error
 ZSTATUS=haltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
 # Halt 2
+ZSTATUS=haltfn+6^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
 ls: No match.
 # -------------------------------------------------------------------------------------------
 # Two consecutive zhalts with a pause
 # Zhalt 1, Expect a RESTRICTEDOP error
 ZSTATUS=zhaltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
 # Zhalt 2
+ZSTATUS=zhaltfn+6^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
 ls: No match.
 # -------------------------------------------------------------------------------------------
 # Confirming ZHALT,ZGOTO 0 produces an error in the shell

--- a/v63003/outref/gtm8844.txt
+++ b/v63003/outref/gtm8844.txt
@@ -1,25 +1,37 @@
 # Running functions that violate our restrictions
-# Expect two GTM_FATAL files at the bottom of the reference file
 # -------------------------------------------------------------------------------------------
 # Two consecutive halts
 # Halt 1, Expect a RESTRICTEDOP error
 ZSTATUS=haltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
-# Halt 2, Expect a RESTRICTEDOP fatal error
+# Halt 2
 %YDB-F-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
 ##TEST_AWKYDB_FATAL_ERROR.ZSHOW_DMP_[0-9]*_1.txt
 # -------------------------------------------------------------------------------------------
 # Two consecutive zhalts
 # Zhalt 1, Expect a RESTRICTEDOP error
 ZSTATUS=zhaltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
-# Zhalt 2, Expect a RESTRICTEDOP fatal error
+# Zhalt 2
 %YDB-F-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
 ##TEST_AWKYDB_FATAL_ERROR.ZSHOW_DMP_[0-9]*_1.txt
+# -------------------------------------------------------------------------------------------
+# Two consecutive halts with a pause
+# Halt 1, Expect a RESTRICTEDOP error
+ZSTATUS=haltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
+# Halt 2
+ls: No match.
+# -------------------------------------------------------------------------------------------
+# Two consecutive zhalts with a pause
+# Zhalt 1, Expect a RESTRICTEDOP error
+ZSTATUS=zhaltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
+# Zhalt 2
+ls: No match.
 # -------------------------------------------------------------------------------------------
 # Confirming ZHALT,ZGOTO 0 produces an error in the shell
 ZSTATUS=zgotofn+2^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
 $ZTRAP=
 $ECODE=,Z150384210,
 Status After ZGOTOFN=82
+Error Detected
 # -------------------------------------------------------------------------------------------
 ==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "set ^X=0  set ^Y=0"'==
 File trigger.txt, Line 1: Added SET trigger on ^X named triggerx
@@ -32,7 +44,7 @@ File trigger.txt, Line 2: Added SET trigger on ^Y named triggery
 0 trigger file entries did not update database trigger content
 =========================================
 
-# Test for ZHALT in a trigger
+# Test ZHALT in a trigger takes down the update process
 # Setting off Trigger
 ==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "set ^X=1"'==
 # Check primary
@@ -52,16 +64,15 @@ PID ##FILTERED##[##PID##] Update process is alive
 ==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^X,!"'==
 1
 # -------------------------------------------------------------------------------------------
-# Test for HALT in a trigger
 # Setting off Trigger
 ==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "set ^Y=1"'==
 # Check primary
 ==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "write ^Y"'==
 1
 # Check secondary
-==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^Y"'==
+==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^Y,!"'==
 0
-==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth >& checkhealth.tmp; cat checkhealth.tmp'==
+==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth >& checkhealth.tmp ; cat checkhealth.tmp'==
 PID ##FILTERED##[##PID##] Receiver server is alive
 ##TEST_AWKPID [0-9]* Update process is NOT alive
 # Restore the update process
@@ -69,5 +80,6 @@ PID ##FILTERED##[##PID##] Receiver server is alive
 ==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth'==
 PID ##FILTERED##[##PID##] Receiver server is alive
 PID ##FILTERED##[##PID##] Update process is alive
-==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^Y"'==
+==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^Y,!"'==
 1
+# -------------------------------------------------------------------------------------------

--- a/v63003/outref/gtm8844.txt
+++ b/v63003/outref/gtm8844.txt
@@ -1,0 +1,73 @@
+# Running functions that violate our restrictions
+# Expect two GTM_FATAL files at the bottom of the reference file
+# -------------------------------------------------------------------------------------------
+# Two consecutive halts
+# Halt 1, Expect a RESTRICTEDOP error
+ZSTATUS=haltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
+# Halt 2, Expect a RESTRICTEDOP fatal error
+%YDB-F-RESTRICTEDOP, Attempt to perform a restricted operation: HALT
+##TEST_AWKYDB_FATAL_ERROR.ZSHOW_DMP_[0-9]*_1.txt
+# -------------------------------------------------------------------------------------------
+# Two consecutive zhalts
+# Zhalt 1, Expect a RESTRICTEDOP error
+ZSTATUS=zhaltfn+3^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
+# Zhalt 2, Expect a RESTRICTEDOP fatal error
+%YDB-F-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
+##TEST_AWKYDB_FATAL_ERROR.ZSHOW_DMP_[0-9]*_1.txt
+# -------------------------------------------------------------------------------------------
+# Confirming ZHALT,ZGOTO 0 produces an error in the shell
+ZSTATUS=zgotofn+2^gtm8844,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZHALT
+$ZTRAP=
+$ECODE=,Z150384210,
+Status After ZGOTOFN=82
+# -------------------------------------------------------------------------------------------
+==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "set ^X=0  set ^Y=0"'==
+File trigger.txt, Line 1: Added SET trigger on ^X named triggerx
+File trigger.txt, Line 2: Added SET trigger on ^Y named triggery
+=========================================
+2 triggers added
+0 triggers deleted
+0 triggers modified
+2 trigger file entries did update database trigger content
+0 trigger file entries did not update database trigger content
+=========================================
+
+# Test for ZHALT in a trigger
+# Setting off Trigger
+==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "set ^X=1"'==
+# Check primary
+==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "write ^X"'==
+1
+# Check secondary
+==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^X,!"'==
+0
+==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth >& checkhealth.tmp ; cat checkhealth.tmp'==
+PID ##FILTERED##[##PID##] Receiver server is alive
+##TEST_AWKPID [0-9]* Update process is NOT alive
+# Restore the update process
+# Confirm secondary's update process is restored and database is up to date
+==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth'==
+PID ##FILTERED##[##PID##] Receiver server is alive
+PID ##FILTERED##[##PID##] Update process is alive
+==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^X,!"'==
+1
+# -------------------------------------------------------------------------------------------
+# Test for HALT in a trigger
+# Setting off Trigger
+==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "set ^Y=1"'==
+# Check primary
+==Executing MULTISITE_REPLIC 'RUN INST1 $ydb_dist/mumps -run ^%XCMD "write ^Y"'==
+1
+# Check secondary
+==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^Y"'==
+0
+==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth >& checkhealth.tmp; cat checkhealth.tmp'==
+PID ##FILTERED##[##PID##] Receiver server is alive
+##TEST_AWKPID [0-9]* Update process is NOT alive
+# Restore the update process
+# Confirm secondary's update process is restored and database is up to date
+==Executing MULTISITE_REPLIC 'RUN INST2 $MUPIP replic -receiver -checkhealth'==
+PID ##FILTERED##[##PID##] Receiver server is alive
+PID ##FILTERED##[##PID##] Update process is alive
+==Executing MULTISITE_REPLIC 'RUN INST2 $ydb_dist/mumps -run ^%XCMD "write ^Y"'==
+1

--- a/v63003/outref/outref.txt
+++ b/v63003/outref/outref.txt
@@ -40,5 +40,6 @@ PASS from gtm8732r
 PASS from gtm8795
 PASS from gtm8794
 PASS from gtm8850
+PASS from gtm8844
 ##ALLOW_OUTPUT NON_REPLIC
 v63003 test DONE.

--- a/v63003/u_inref/gtm8844.csh
+++ b/v63003/u_inref/gtm8844.csh
@@ -52,10 +52,7 @@ echo "# ------------------------------------------------------------------------
 echo "# Confirming ZHALT,ZGOTO 0 produces an error in the shell"
 $ydb_dist/mumps -run zgotofn^gtm8844
 set exitstatus=$status
-echo "Status After ZGOTOFN=$exitstatus"
-if ($exitstatus) then
-	echo "Error Detected"
-endif
+echo '$Status in Shell After ZGOTOFN='$exitstatus
 echo "# -------------------------------------------------------------------------------------------"
 $MULTISITE_REPLIC_PREPARE 2
 # Set up a non replicated region HREG for our trigger activities (the 9th region from the dbcreate)
@@ -86,7 +83,7 @@ foreach var (^X ^Y)
 	$MSR RUN INST2 'set msr_dont_trace ; $gtm_tst/com/wait_for_proc_to_die.csh' $updprocpid
 	$MSR RUN INST2 '$MUPIP replic -receiver -checkhealth >& checkhealth.tmp ; cat checkhealth.tmp' >& checkhealth.out
 	cat checkhealth.out
-	echo "# Restore the update process"
+	echo "# Restart the update process"
 	# Using outx because we are expecting errors
 	$MSR STOPRCV INST1 INST2 >>& restart.outx
 	$MSR RUN INST2 '$ydb_dist/mumps -run ^%XCMD "set ^H=1;write ^H"'>>& restart.outx

--- a/v63003/u_inref/gtm8844.csh
+++ b/v63003/u_inref/gtm8844.csh
@@ -11,7 +11,9 @@
 #								#
 #################################################################
 
-
+setenv start_time `cat start_time`
+setenv srcLog2 "SRC_$start_time.log"
+setenv portno `$sec_shell "$sec_getenv; source $gtm_tst/com/portno_acquire.csh"`
 # Lack permissions to write to the $ydb_dist directory, so we are creating a temp directory
 # and copying all files from $ydb_dist to temp, changing the ydb_dist environment variable
 # and putting restrict.txt in temp
@@ -27,26 +29,45 @@ chmod -w $ydb_dist/restrict.txt
 
 # Creating trigger file
 cat > trigger.txt << EOF
-+^X -command =set -xecute="do zgotofn^gtm8844"
++^X -name=triggered -command=set -xecute="do zgotofn^gtm8844"
 EOF
 
-echo "# Running functions that violate out restrictions, expect a RESTRICTEDOP error and then GTM_FATAL FILE"
+echo "# Running functions that violate our restrictions"
+echo "# Expect two GTM_FATAL files at the bottom of the reference file"
 echo "# -------------------------------------------------------------------------------------------"
 echo "# Two consecutive halts"
 $ydb_dist/mumps -run haltfn^gtm8844
 echo "# -------------------------------------------------------------------------------------------"
 echo "# Two consecutive zhalts"
 $ydb_dist/mumps -run zhaltfn^gtm8844
-echo "# -------------------------------------------------------------------------------------------"
+echo ""
+echo ""
+echo ""
 echo ""
 echo ""
 echo "# Confirming ZHALT,ZGOTO 0 produces an error in the shell"
 $ydb_dist/mumps -run zgotofn^gtm8844
-echo "status after zgotofn=$status"
+echo "Status After ZGOTOFN=$status"
+if !($status) then
+	echo "Error Detected"
+endif
 echo "# -------------------------------------------------------------------------------------------"
 $gtm_tst/com/dbcreate.csh mumps 1 >>& dbcreate.out
 $MUPIP trigger -triggerfile=trigger.txt
 $ydb_dist/mumps -run ^%XCMD "set ^X=1"
-$ydb_dist/mumps -run ^%XCMD "write ^X"
-$sec_shell "cd $SEC_SIDE; $ydb_dist0/mumps -run ^%XCMD ""write ^X"""
+
+
+# dont move on until the error has been generated in the source log
+$gtm_tst/com/wait_for_log.csh -message "YDB-E" -log $srcLog2 -duration 300
+#echo '' >> $outputFile
+#echo "# INST1 INST2 source server log errors:" >> $outputFile
+#$grep -e "-E-" $srcLog1  >> $outputFile
+#echo "# INST1 INST3 source server log errors:" >> $outputFile
+#$grep -e "-E-" $srcLog2  >> $outputFile
+#echo '' >> $outputFile
+
+
+$ydb_dist/mumps -run ^%XCMD "set ^Y=1"
+$ydb_dist/mumps -run ^%XCMD "write ^Y"
+$sec_shell "cd $SEC_SIDE; $ydb_dist0/mumps -run ^%XCMD ""write ^Y"""
 $gtm_tst/com/dbcheck.csh >>& dbcheck.out

--- a/v63003/u_inref/gtm8844.csh
+++ b/v63003/u_inref/gtm8844.csh
@@ -1,0 +1,52 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+
+
+# Lack permissions to write to the $ydb_dist directory, so we are creating a temp directory
+# and copying all files from $ydb_dist to temp, changing the ydb_dist environment variable
+# and putting restrict.txt in temp
+mkdir temp
+cp $ydb_dist/* temp/
+set ydb_dist0=$ydb_dist
+setenv ydb_dist temp
+cat > $ydb_dist/restrict.txt << EOF
+ZHALT
+HALT
+EOF
+chmod -w $ydb_dist/restrict.txt
+
+# Creating trigger file
+cat > trigger.txt << EOF
++^X -command =set -xecute="do zgotofn^gtm8844"
+EOF
+
+echo "# Running functions that violate out restrictions, expect a RESTRICTEDOP error and then GTM_FATAL FILE"
+echo "# -------------------------------------------------------------------------------------------"
+echo "# Two consecutive halts"
+$ydb_dist/mumps -run haltfn^gtm8844
+echo "# -------------------------------------------------------------------------------------------"
+echo "# Two consecutive zhalts"
+$ydb_dist/mumps -run zhaltfn^gtm8844
+echo "# -------------------------------------------------------------------------------------------"
+echo ""
+echo ""
+echo "# Confirming ZHALT,ZGOTO 0 produces an error in the shell"
+$ydb_dist/mumps -run zgotofn^gtm8844
+echo "status after zgotofn=$status"
+echo "# -------------------------------------------------------------------------------------------"
+$gtm_tst/com/dbcreate.csh mumps 1 >>& dbcreate.out
+$MUPIP trigger -triggerfile=trigger.txt
+$ydb_dist/mumps -run ^%XCMD "set ^X=1"
+$ydb_dist/mumps -run ^%XCMD "write ^X"
+$sec_shell "cd $SEC_SIDE; $ydb_dist0/mumps -run ^%XCMD ""write ^X"""
+$gtm_tst/com/dbcheck.csh >>& dbcheck.out


### PR DESCRIPTION
Tests the following release note:

The GT.M restrictions facility recognizes HALT[:<group-name>] and ZHALT[:<group-name>]. When either is present and restriction conditions are met, the restricted command produces a RESTRICTEDOP error. In order to limit pathological looping, if A GT.M process issues a second occurrence of the restricted command within half a second, it terminates after sending a fatal error to both the principal device and the syslog, and also producing a GTM_FATAL* context file, but no core file. Note that, With these restrictions in place, a process should terminate with, for example: ZGOTO 0. with or without a restriction, executing these commands as part triggered logic on a replicating instance may cause the Update Server to terminate and thereby stop replication. As part of this change when ""=$ZTRAP and ""!=$ECODE, ZGOTO 0 returns a non-zero status, derived from the error code in $ZSTATUS, to the shell. If you have an application that uses ZHALT, ZGOTO 0 and shell scripts that check returned status, you should review things in light of this change. Note: with appropriate error handling, an application can use one or both of these restrictions to perform clean up after any explicit HALT or ZHALT. Previously, the restrictions facility did not support these two restrictions, and $ZGOT: 0 always returned a success status to the shell. (GTM-8844)