### PR TITLE
Fix gtm8699 addition to gtm8086 test

### DIFF
--- a/v62000/u_inref/gtm8086.csh
+++ b/v62000/u_inref/gtm8086.csh
@@ -153,7 +153,7 @@ if ($?test_replic) then
 		# getoper will capture syslog messages generated since starting the jnlswitchretry error
 		$gtm_tst/com/getoper.csh "$jnlswitchretry_time"
 		# Confirm there is no PREVJNLLINKCUT error in the output
-		$grep -e "PREVJNLLINKCUT" syslog.txt
+		$grep -e "$PWD" syslog.txt | $grep -e "PREVJNLLINKCUT"
 
 
 	endif

--- a/v62000/u_inref/gtm8086.csh
+++ b/v62000/u_inref/gtm8086.csh
@@ -153,7 +153,7 @@ if ($?test_replic) then
 		# getoper will capture syslog messages generated since starting the jnlswitchretry error
 		$gtm_tst/com/getoper.csh "$jnlswitchretry_time"
 		# Confirm there is no PREVJNLLINKCUT error in the output
-		$grep -e "$PWD" syslog.txt | $grep -e "PREVJNLLINKCUT"
+		$grep "PREVJNLLINKCUT" | $grep "$PWD" syslog.txt
 
 
 	endif

--- a/v62000/u_inref/gtm8086.csh
+++ b/v62000/u_inref/gtm8086.csh
@@ -153,7 +153,7 @@ if ($?test_replic) then
 		# getoper will capture syslog messages generated since starting the jnlswitchretry error
 		$gtm_tst/com/getoper.csh "$jnlswitchretry_time"
 		# Confirm there is no PREVJNLLINKCUT error in the output
-		$grep "PREVJNLLINKCUT" | $grep "$PWD" syslog.txt
+		$grep "PREVJNLLINKCUT" syslog.txt | $grep "$PWD"
 
 
 	endif


### PR DESCRIPTION
Previously gtm8699 code block c…ould pick up PREVJNLLINKCUT errors from other subtests in the syslog