### PR TITLE
Enhance test framework to use POSIX plugin even in UTF8 mode

### DIFF
--- a/com/set_gtmroutines.csh
+++ b/com/set_gtmroutines.csh
@@ -90,8 +90,9 @@ if (-d ${gtm_exe}/plugin/o${utf8} && -d ${gtm_exe}/plugin/r) then
 else
 	set plugrtns = ""
 endif
-if (-e ${gtm_exe}/plugin/o/_POSIX.so) then
-	set plugrtns = " ${gtm_exe}/plugin/o/_POSIX.so $plugrtns"
+# If _POSIX.so exists, use that ahead of _POSIX.m (to avoid permission errors while trying to create plugin/o/_POSIX.o)
+if (-e ${gtm_exe}/plugin/o${utf8}/_POSIX.so) then
+	set plugrtns = " ${gtm_exe}/plugin/o${utf8}/_POSIX.so${star2} $plugrtns"
 endif
 set exedir = "$gtm_exe${utf8}${star2}${plugrtns}"
 set gtm_routines_var = "${gtm_routines_var} ${exedir}"


### PR DESCRIPTION
Note though that there are issues still with the POSIX plugin Makefile which will be fixed separately.

Currently the POSIX plugin Makefile builds plugin/o/_POSIX.so and plugin/o/utf8/_POSIX.so
But the latter contains object files corresponding to M mode (and not UTF-8 mode).
This is incorrect and needs to be fixed in the POSIX plugin. Until that is done, the
test system framework change to enable POSIX plugin usage cannot be used in -unicode mode.