### PR TITLE
Enhance test framework to record test failure in D_ALL, subtest.diff and diff.log for HANG/TIMEDOUT alerts

### DIFF
--- a/com/submit.awk
+++ b/com/submit.awk
@@ -1,6 +1,9 @@
 #################################################################
 #								#
-#	Copyright 2002, 2014 Fidelity Information Services, Inc	#
+# Copyright 2002, 2014 Fidelity Information Services, Inc	#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -81,6 +84,13 @@ $1 !~ /#/ {testname = $2 "_" $1
  if (ENVIRON["test_want_concurrency"]=="yes") printf " &"
  printf "\n"
  print "set teststat = $status"
+ print "# It is possible the test got kill -9ed (by gtm_test_watchdog.csh due to a TIMEDOUT alert)."
+ print "# In that case, the exit status would be 128 + 9 (kill -9) = 137. Handle that specially."
+ print "if ((137 == $teststat) && $?test_distributed) then"
+ print "	set donefile = ${test_distributed}.done"
+ print "	# Note down in the file that this test is done"
+ print "	$test_distributed_srvr \"$gtm_tst/com/distributed_test_pick.csh donetest $testname $short_host FAILED $donefile $gtm_tst\""
+ print "endif"
  print "end_"testname":"
  print "if ($teststat != 0 ) set stat = $teststat"
  print "if ($?test_no_background) then"

--- a/com/submit_test.csh
+++ b/com/submit_test.csh
@@ -1103,11 +1103,6 @@ if ($?testtiming_log) then
 	endif
 endif
 ############################################################
-if ($?test_distributed) then
-	set donefile = ${test_distributed}.done
-	# Note down in the file that this test is done
-	$test_distributed_srvr "$gtm_tst/com/distributed_test_pick.csh donetest $testname $short_host $log_line_stat $donefile $gtm_tst"
-endif
 if (1 == $stat) then
 	# Lets signal a "test failure" to the caller (differentiate with the other exit 1 states)
 	exit 99


### PR DESCRIPTION
This helps easily find out all subtests which have failed/hung/timedout in a D_ALL
by just checking for the presence of <subtest>.diff files.