### PR TITLE
Fix suppl_inst_B/supplementary_err test failure due to recent _POSIX.so addition to ydb_routines/gtmroutines

### DIFF
--- a/com/set_active_version.csh
+++ b/com/set_active_version.csh
@@ -28,8 +28,10 @@ if ($?gtmroutines) then
 	set rtns = ($gtmroutines:x)
 	if (0 < $#rtns) then
 		@ rtncnt = $#rtns
-		# Strip off "$gtm_exe/plugin/o($gtm_exe/plugin/r)" if present; assumption, it's at the end
+		# Strip off "$gtm_exe/plugin/o($gtm_exe/plugin/r)" if present; assumption, it's last in the list
 		if ("$rtns[$rtncnt]" =~ "*/plugin/o*(*/plugin/r)") @ rtncnt--
+		# Strip off "$gtm_exe/plugin/o/_POSIX.so" if present; assumption, it's last but one in the list
+		if ("$rtns[$rtncnt]" =~ "*/plugin/o*/_POSIX.so") @ rtncnt--
 		setenv gtmroutines "$rtns[-$rtncnt]"
 		unset rtncnt
 	else


### PR DESCRIPTION
When switching to an older version, a script com/set_active_version.csh was being invoked which
stripped off plugin related obj dirs. That was not updated to strip off _POSIX.so element in
the list (which was added by a recent commit to set_gtmroutines.csh). This caused a dbcreate done
in the suppl_inst_B/supplementary_err test after switching to an old 32-bit build of GT.M
(e.g. V53002) to issue a DLLNOOPEN error (type ELFCLASS64) due to the presence of the 64-bit
_POSIX.so in the gtmroutines list of a 32-bit GT.M build. Now fixed to strip off _POSIX.so
just like it already stripped off other plugin components in the list.