### PR TITLE
Fix test framework so it records test status (success or failure) in D_ALL

### DIFF
--- a/com/submit_test.csh
+++ b/com/submit_test.csh
@@ -1103,6 +1103,11 @@ if ($?testtiming_log) then
 	endif
 endif
 ############################################################
+if ($?test_distributed) then
+	set donefile = ${test_distributed}.done
+	# Note down in the file that this test is done
+	$test_distributed_srvr "$gtm_tst/com/distributed_test_pick.csh donetest $testname $short_host $log_line_stat $donefile $gtm_tst"
+endif
 if (1 == $stat) then
 	# Lets signal a "test failure" to the caller (differentiate with the other exit 1 states)
 	exit 99


### PR DESCRIPTION
As part of a prior commit, pre-existing logic in com/submit_test.csh was removed
as similar logic was added to com/submit.awk. But the latter only handled the case
when the test was killed by the gtm_test_watchdog.csh script. The most common case
of a test passing or failing is handled in com/submit_test.csh and should stay as
is (since PASSED or FAILED status is known only to com/submit_test.csh). So restore
the code removed in com/submit_test.csh.