### PR TITLE
Fix online_rollback/forest subtest failure on slow systems by bumping waittime from 10 minutes to 1 hour

### DIFF
--- a/online_rollback/inref/cascade.m
+++ b/online_rollback/inref/cascade.m
@@ -1,8 +1,22 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; This module is derived from FIS GT.M.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 cascade
 	write "Nothing here"
 	quit
 
 waitfororlbk
-	set waittime=600,neederr=1
+	set waittime=3600,neederr=1
 	do FUNC^waitforfilecreate("ONLINE_ROLLBACK.complete",waittime,neederr)
 	quit


### PR DESCRIPTION
In a test run on a slow box, it took 16 minutes for a file ONLINE_ROLLBACK.complete to be created
causing the test to fail because it had a 10 minute timeout. That is now bumped to 1 hour.