### PR TITLE
Fix occasional v60000/gtm7231 subtest failure due to lack of white-box test setup during MUPIP RUNDOWN

### DIFF
--- a/v60000/u_inref/gtm7231.csh
+++ b/v60000/u_inref/gtm7231.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2013-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -41,7 +44,7 @@ echo "Test 2: create a database with crash, then start the journal extraction pr
 $echoline
 
 $gtm_tst/com/dbcreate.csh mumps 1
-# enable the white-box test setup to avoid an assert failure due to the crash.
+# Enable the white-box test setup to avoid an assert failure due to the crash.
 setenv gtm_white_box_test_case_number 29
 setenv gtm_white_box_test_case_enable 1
 # In the following wc_blocked won't be set, just let a gtm process kill itself
@@ -50,7 +53,6 @@ $gtm_exe/mumps -run setWcBlockedAndKillSelf >>&! setWcBlockedAndKillSelf.out
 set extra1_pid=`cat extra1.pid`
 $gtm_tst/com/wait_for_proc_to_die.csh $extra1_pid 120
 $MUPIP journal -extract=mumps.mjf -noverify -detail -forward -fences=none mumps.mjl >&! extra2.log
-unsetenv gtm_white_box_test_case_enable
 
 $tail -3 mumps.mjf | $tst_awk '{print $5}' | $tst_awk 'BEGIN {FS="\\\\"} ; {print $5}' >& last_process.log
 
@@ -61,4 +63,8 @@ $grep extra1_pid last_process.log
 $MUPIP rundown -relinkctl >&! mupip_rundown_rctl.logx
 
 # Clean up expected orphaned shared memory segment and semaphore
+# Note that even the MUPIP rundown here requires the white-box test setup to avoid assert failures
+# hence the "unsetenv gtm_white_box_test_case_enable" happens at the end of this script.
 $MUPIP rundown -override -region "*" >&! mupip_rundown.logx
+
+unsetenv gtm_white_box_test_case_enable


### PR DESCRIPTION
The v60000/gtm7231 subtest failed once (in a lot of runs)with an assert failure in MUPIP RUNDOWN.
The assert failed in WCS_FLU.C because we found no dirty cache-record in the active queue but the
dirty queue cnt (cnl->wcs_active_lvl) is non-zero. This is expected since this test does kill -9s
and depending on when the kill9 happens, we could end up with this scenario.

The test already sets a white-box variable indicating this is a crash case. But it unsets this right
after the MUPIP journal extract. Whereas this white-box setup is needed even until later when we
run the MUPIP rundown. The "unsetenv gtm_white_box_test_case_enable" is now moved to the end of
the script. That should ensure the white-box setup is there all through.