### PR TITLE
Fix gtm8889

### DIFF
--- a/v63003/outref/gtm8889.txt
+++ b/v63003/outref/gtm8889.txt
@@ -11,16 +11,16 @@ SHELLYDB
 $ydb_dist/mumps -dir
 YDB>zhelp
 Additional information available: 
-About_GT.M  Commands    Err_Processing          Functions   Integrate_External
-Internationalization    IO_Processing           ISV         Language_Extensions
-M_Lang_Features         Opr_Dbg_Dir_Mode        Program_Cycle           
-Triggers    Utility_Routines        
+About_YottaDB           Commands    Err_Processing          Functions
+Integrate_External      Internationalization    IO_Processing           
+ISV         Language_Extensions     M_Lang_Features         Opr_Dbg_Dir_Mode
+Program_Cycle           Triggers    Utility_Routines        
 Topic? #<Ctrl-C>
 Additional information available: 
-About_GT.M  Commands    Err_Processing          Functions   Integrate_External
-Internationalization    IO_Processing           ISV         Language_Extensions
-M_Lang_Features         Opr_Dbg_Dir_Mode        Program_Cycle           
-Triggers    Utility_Routines        
+About_YottaDB           Commands    Err_Processing          Functions
+Integrate_External      Internationalization    IO_Processing           
+ISV         Language_Extensions     M_Lang_Features         Opr_Dbg_Dir_Mode
+Program_Cycle           Triggers    Utility_Routines        
 Topic? 
 YDB>halt
 SHELL

--- a/v63003/outref/gtm8889.txt
+++ b/v63003/outref/gtm8889.txt
@@ -4,33 +4,23 @@
 
 spawn /usr/local/bin/tcsh -f
 > # Expect the shell prompt
-stty cols 132
-> YDB
+set shellprompt=SHELL
+> set prompt=$shellprompt
+SHELLstty cols 132
+SHELLYDB
 $ydb_dist/mumps -dir
-
 YDB>zhelp
-
-
-
 Additional information available: 
-
-About_YottaDB           Commands    Err_Processing          Functions
-Integrate_External      Internationalization    IO_Processing           
-ISV         Language_Extensions     M_Lang_Features         Opr_Dbg_Dir_Mode
-Program_Cycle           Triggers    Utility_Routines        
-
+About_GT.M  Commands    Err_Processing          Functions   Integrate_External
+Internationalization    IO_Processing           ISV         Language_Extensions
+M_Lang_Features         Opr_Dbg_Dir_Mode        Program_Cycle           
+Triggers    Utility_Routines        
 Topic? #<Ctrl-C>
-
-
-
-
 Additional information available: 
-
-About_YottaDB           Commands    Err_Processing          Functions
-Integrate_External      Internationalization    IO_Processing           
-ISV         Language_Extensions     M_Lang_Features         Opr_Dbg_Dir_Mode
-Program_Cycle           Triggers    Utility_Routines        
-
+About_GT.M  Commands    Err_Processing          Functions   Integrate_External
+Internationalization    IO_Processing           ISV         Language_Extensions
+M_Lang_Features         Opr_Dbg_Dir_Mode        Program_Cycle           
+Triggers    Utility_Routines        
 Topic? 
-
 YDB>halt
+SHELL

--- a/v63003/u_inref/gtm8889.csh
+++ b/v63003/u_inref/gtm8889.csh
@@ -26,4 +26,4 @@ if ($status) then
 endif
 perl $gtm_tst/com/expectsanitize.pl expect.outx > expect_sanitized.outx
 
-cat expect_sanitized.outx
+$grep -v '^$' expect_sanitized.outx

--- a/v63003/u_inref/gtm8889.exp
+++ b/v63003/u_inref/gtm8889.exp
@@ -25,12 +25,23 @@ proc timeout_procedure { } {
 
 expect -exact ">"
 puts "# Expect the shell prompt"
+# Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
+#	send -- "set prompt=SHELL\r"
+#	expect -exact "SHELL"
+# But that will not work because it is possible the "expect" matches the SHELL from the "set prompt=SHELL" input
+# instead of from the SHELL prompt later spewed out by the shell. To avoid this, we first store the "SHELL" string
+# in a shell variable and use that variable in another line to set the prompt.
+send -- "set shellprompt=SHELL\r"
+expect -exact ">"
+send -- "set prompt=\$shellprompt\r"
+expect -exact "SHELL"
+
 
 # Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
 send -- "stty cols 132\r"
 expect "stty cols 132\r"
 
-expect -exact ">"
+expect -exact "SHELL"
 puts "YDB"
 send -- "\$ydb_dist/mumps -dir\r"
 expect -exact "YDB>"
@@ -41,6 +52,6 @@ send "\x03\r"
 send "\r"
 expect -exact "YDB>"
 send "halt\r"
-expect ">"
+expect -exact "SHELL"
 send "exit\r"
 


### PR DESCRIPTION
change shell prompt to 'SHELL' in gtm8889.exp to avoid false positives from expect ">" commands. 
Avoid issue with inconsistent number of blank lines by grepping for non-blank lines in output in gtm8889.csh