### PR TITLE
Fix occasional unicode_io/unicodefifo subtest failure on slow systems

### DIFF
--- a/unicode_io/inref/unicodefifo.m
+++ b/unicode_io/inref/unicodefifo.m
@@ -3,6 +3,9 @@
 ; Copyright (c) 2006-2015 Fidelity National Information		;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -29,12 +32,12 @@ unicodefifo(encoding);
 	set ^A=1
 	do test(file,"FIFO:WRITE:RECORDSIZE=-1","",FAIL)
 	set ^A=0
-	f i=1:1:60 quit:^A  hang 1
+	f i=1:1:900 quit:^A  hang 1
 	do checkfile(file)
 	set ^A=0
 	write jobstr,!
 	job @jobstr
-	for i=1:1:60 quit:^A  hang 1
+	for i=1:1:900 quit:^A  hang 1
 	if 0=^A write "FIFO reader couldn't start, exiting",! quit
 	hang 1
 	;;;;;
@@ -70,7 +73,7 @@ unicodefifo(encoding);
 	use file
 	write "QUIT"
 	close file
-	for i=1:1:60 quit:2=^B  hang 1
+	for i=1:1:900 quit:2=^B  hang 1
 	if 2'=^B write "Reader process is taking too long",!
 	quit
 test(dev,openpar,usepar,expfail) ;
@@ -107,7 +110,7 @@ unicodefifo2(file,encoding) ;
 	set ^A=1
 	do open^io(file,"FIFO:READ:RECORDSIZE=1048576",encoding,100)
 	; wait until actual write is ready before doing a read
-	for i=1:1:60 quit:^B  hang 1
+	for i=1:1:900 quit:^B  hang 1
 	if 0=^B write "Writer process is taking too long",!
 	for i=1:1:100 use file:WIDTH=1048576 read message:40 set t=$T use $PRINCIPAL if t write "message: ",message,! quit:message="QUIT"  h 1
 	close file
@@ -115,22 +118,22 @@ unicodefifo2(file,encoding) ;
 	quit
 unicodefifo3(file,encoding) ;
 	set $ZTRAP="do error2^unicodefifo"
-	for i=1:1:60 quit:^A  hang 1
+	for i=1:1:900 quit:^A  hang 1
 	if 0=^A write "Writer process is missing",! quit
 	; make sure writer happens first so file is deleted on writer open error
 	set fsize=0
-	for i=1:1:60 quit:fsize  do
+	for i=1:1:900 quit:fsize  do
 	. set fsize=$length($zsearch(file))
-	if 'fsize write file_" not found in 60 seconds",!
+	if 'fsize write file_" not found in 900 seconds",!
 	hang 1
 	do open^io(file,"FIFO:READ:RECORDSIZE=1048576",encoding,100)
-	for i=1:1:60 quit:'^A  hang 1
+	for i=1:1:900 quit:'^A  hang 1
 	if 1=^A write "Writer process is taking too long",!
 	close file
 	; we expect file to be gone before checkfile
-	for i=1:1:60 quit:'fsize  do
+	for i=1:1:900 quit:'fsize  do
 	. set fsize=$length($zsearch(file))
-	if fsize write file_" not removed in 60 seconds",!
+	if fsize write file_" not removed in 900 seconds",!
 	set ^A=1
 	quit
 checkfile(file)	;

--- a/unicode_io/inref/unicodefifo.m
+++ b/unicode_io/inref/unicodefifo.m
@@ -33,12 +33,13 @@ unicodefifo(encoding);
 	do test(file,"FIFO:WRITE:RECORDSIZE=-1","",FAIL)
 	set ^A=0
 	f i=1:1:900 quit:^A  hang 1
+	if 0=^A write "FIFO reader unicodefifo3^unicodefifo couldn't start, exiting",! quit
 	do checkfile(file)
 	set ^A=0
 	write jobstr,!
 	job @jobstr
 	for i=1:1:900 quit:^A  hang 1
-	if 0=^A write "FIFO reader couldn't start, exiting",! quit
+	if 0=^A write "FIFO reader unicodefifo2^unicodefifo couldn't start, exiting",! quit
 	hang 1
 	;;;;;
 	do test(file,"FIFO:WRITE:RECORDSIZE=-1","",FAIL)
@@ -74,7 +75,7 @@ unicodefifo(encoding);
 	write "QUIT"
 	close file
 	for i=1:1:900 quit:2=^B  hang 1
-	if 2'=^B write "Reader process is taking too long",!
+	if 2'=^B write "Reader process is taking too long",! quit
 	quit
 test(dev,openpar,usepar,expfail) ;
 	write "---------------------------------------------",!
@@ -111,7 +112,7 @@ unicodefifo2(file,encoding) ;
 	do open^io(file,"FIFO:READ:RECORDSIZE=1048576",encoding,100)
 	; wait until actual write is ready before doing a read
 	for i=1:1:900 quit:^B  hang 1
-	if 0=^B write "Writer process is taking too long",!
+	if 0=^B write "Writer process is taking too long",! quit
 	for i=1:1:100 use file:WIDTH=1048576 read message:40 set t=$T use $PRINCIPAL if t write "message: ",message,! quit:message="QUIT"  h 1
 	close file
 	set ^B=2
@@ -124,16 +125,16 @@ unicodefifo3(file,encoding) ;
 	set fsize=0
 	for i=1:1:900 quit:fsize  do
 	. set fsize=$length($zsearch(file))
-	if 'fsize write file_" not found in 900 seconds",!
+	if 'fsize write file_" not found in 900 seconds",! quit
 	hang 1
 	do open^io(file,"FIFO:READ:RECORDSIZE=1048576",encoding,100)
 	for i=1:1:900 quit:'^A  hang 1
-	if 1=^A write "Writer process is taking too long",!
+	if 1=^A write "Writer process is taking too long",! quit
 	close file
 	; we expect file to be gone before checkfile
 	for i=1:1:900 quit:'fsize  do
 	. set fsize=$length($zsearch(file))
-	if fsize write file_" not removed in 900 seconds",!
+	if fsize write file_" not removed in 900 seconds",! quit
 	set ^A=1
 	quit
 checkfile(file)	;

--- a/unicode_io/inref/zunicodefifo.m
+++ b/unicode_io/inref/zunicodefifo.m
@@ -59,6 +59,7 @@ zunicodefifo(encoding);
 	;tell reader we are ready to write
 	set ^B=1
 	for i=1:1:900 quit:^A  hang 1
+	if 0=^A write "FIFO reader unicodefifo2^zunicodefifo couldn't start or taking too long, exiting",! quit
 	h 5
 	write longstr,!
 	;;;;;
@@ -103,6 +104,7 @@ unicodefifo2(file,encoding) ;
 	write "encoding=",encoding,!
 	lock ^fifolock
 	for i=1:1:900 quit:^B  hang 1
+	if 0=^B write "FIFO writer zunicodefifo2^zunicodefifo taking too long, exiting",! quit
 	do open^io(file,"FIFO:READ:RECORDSIZE=1048576",encoding,100)
 	set ^A=1
 	for i=1:1:100 use file:WIDTH=1048576 read message:40 set t=$T use $PRINCIPAL if t write "message: ",message,! quit:message="QUIT"  h 1

--- a/unicode_io/inref/zunicodefifo.m
+++ b/unicode_io/inref/zunicodefifo.m
@@ -1,9 +1,23 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; This module is derived from FIS GT.M.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 zunicodefifo(encoding);
 	;FIFO - RECORDSIZE and WIDTH limits for FIFO devices"
 	;This code is similar to unicodefifo.m, but due to the fact that an open:writeonly
 	;does a successful return without a reading process the synchroniztion of the code is different
 	;there is a comprehensive unicodefifo test in basic
-	;If this routine is modified then a corresponding change to unicodefifo.m may be required	
+	;If this routine is modified then a corresponding change to unicodefifo.m may be required
 	set ^A=0
 	set ^B=0
 	set $ZTRAP="do error^zunicodefifo"
@@ -44,7 +58,7 @@ zunicodefifo(encoding);
 	use file:WIDTH=1048576
 	;tell reader we are ready to write
 	set ^B=1
-	for i=1:1:60 quit:^A  hang 1
+	for i=1:1:900 quit:^A  hang 1
 	h 5
 	write longstr,!
 	;;;;;
@@ -76,8 +90,8 @@ error	;
 	zshow "S"
 	write "Will continue with the rest of the tests...",!
 	if '$DATA(expfail) set expfail="NO"
-	if "FAIL"'=expfail write "FAIL, was not expecting an error!",! 
-	if "FAIL"=expfail write "OK, was expecting an error",! 
+	if "FAIL"'=expfail write "FAIL, was not expecting an error!",!
+	if "FAIL"=expfail write "OK, was expecting an error",!
 	kill expfail	; reset expect FAIL
 	write "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",!
 	zgoto mainlvl
@@ -88,7 +102,7 @@ unicodefifo2(file,encoding) ;
 	write "file=",file,!
 	write "encoding=",encoding,!
 	lock ^fifolock
-	for i=1:1:60 quit:^B  hang 1
+	for i=1:1:900 quit:^B  hang 1
 	do open^io(file,"FIFO:READ:RECORDSIZE=1048576",encoding,100)
 	set ^A=1
 	for i=1:1:100 use file:WIDTH=1048576 read message:40 set t=$T use $PRINCIPAL if t write "message: ",message,! quit:message="QUIT"  h 1
@@ -118,8 +132,8 @@ error2	;
 	zshow "S"
 	write "Will continue with the rest of the tests...",!
 	if '$DATA(expfail) set expfail="NO"
-	if "FAIL"'=expfail write "FAIL, was not expecting an error!",! 
-	if "FAIL"=expfail write "OK, was expecting an error",! 
+	if "FAIL"'=expfail write "FAIL, was not expecting an error!",!
+	if "FAIL"=expfail write "OK, was expecting an error",!
 	kill expfail	; reset expect FAIL
 	write "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",!
 	halt

--- a/unicode_io/outref/unicode_fifo.txt
+++ b/unicode_io/outref/unicode_fifo.txt
@@ -40,8 +40,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+29^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+30^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -54,8 +54,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+30^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+31^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -86,8 +86,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+35^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+36^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -101,8 +101,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+37^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+38^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -122,8 +122,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+41^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+42^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -149,8 +149,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+44^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+45^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -191,8 +191,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+29^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+30^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -205,8 +205,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+30^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+31^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -219,8 +219,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+31^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+32^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -245,8 +245,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+35^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+36^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -260,8 +260,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+37^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+38^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -281,8 +281,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+41^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+42^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -308,8 +308,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+44^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+45^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -350,8 +350,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+29^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+30^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -364,8 +364,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+30^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+31^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -378,8 +378,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+31^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+32^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -404,8 +404,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+35^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+36^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -419,8 +419,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+37^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+38^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -440,8 +440,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+41^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+42^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -467,8 +467,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+44^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+45^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -509,8 +509,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+29^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+30^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -523,8 +523,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+30^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+31^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -537,8 +537,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+31^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+32^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -563,8 +563,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+35^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+36^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -578,8 +578,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+37^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+38^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -599,8 +599,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+41^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+42^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -626,8 +626,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+44^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+45^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -668,8 +668,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+29^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+30^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -682,8 +682,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+30^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+31^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -714,8 +714,8 @@ error+6^unicodefifo
 open+13^io
     ($ZTRAP)
 test+3^unicodefifo
-unicodefifo+35^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+36^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -729,8 +729,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+37^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+38^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -744,8 +744,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+38^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+39^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -777,8 +777,8 @@ error+6^unicodefifo
 use+5^io
     ($ZTRAP)
 test+4^unicodefifo
-unicodefifo+44^unicodefifo
-##TEST_AWK.*\^GTM\$DMOD    \(Direct mode\) 
+unicodefifo+45^unicodefifo
++1^GTM$DMOD    (Direct mode) 
 Will continue with the rest of the tests...
 OK, was expecting an error
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
In a test failure in-house, Line 38 below printed a FIFO reader couldn't start message
causing the failure. We started a job in line 36 and then wait 60 seconds for it to
execute 4 lines (starting from line 103) and set ^A=1 in line 107. But it did not.
Not sure exactly how long it took to reach line 107 so the timeout is now bumped to
 15 minutes (instead of 1 minute) assuming that should be more than good enough.
```
unicode_io/inref/unicodefifo.m
--------------------------------
   35    write jobstr,!
   36    job @jobstr
   37    for i=1:1:60 quit:^A  hang 1
   38    if 0=^A write "FIFO reader couldn't start, exiting",! quit
    .
    .
  102 unicodefifo2(file,encoding) ;
  103    set $ZTRAP="do error2^unicodefifo"
  104    write "$J:",$J,!
  105    write "file=",file,!
  106    write "encoding=",encoding,!
  107    set ^A=1
```