### PR TITLE
Set ydb_repl_filter_timeout env var only if it was not set coming in (helps investigate occasional FILTERTIMEDOUT failures)

### DIFF
--- a/com/set_gtm_machtype.csh
+++ b/com/set_gtm_machtype.csh
@@ -57,9 +57,12 @@ endif
 # Set the variable for 32 bit architectures. Adding more 32bit platforms isn't likely
 if (($gtm_test_machtype == "ix86") || ($gtm_test_machtype == "armvxl")) then
 	setenv gtm_platform_size 32
-	# Increase replication filter timeout on the ARM as we have seen test failures (particularly on ARMV6L)
-	# due to FILTERTIMEDOUT error in the source server log.
-	setenv ydb_repl_filter_timeout 1024	# in seconds. This is 16 times default of 64 seconds
+	# If ydb_repl_filter_timeout env var is defined coming in, honor that setting. If not, set it below.
+	if (! $?ydb_repl_filter_timeout) then
+		# Increase replication filter timeout on the ARM as we have seen test failures (particularly on ARMV6L)
+		# due to FILTERTIMEDOUT error in the source server log.
+		setenv ydb_repl_filter_timeout 1024	# in seconds. This is 16 times default of 64 seconds
+	endif
 else
 	setenv gtm_platform_size 64
 endif


### PR DESCRIPTION
We keep seeing FILTERTIMEDOUT errors in the source server occasionally in test runs of YottaDB
on the ARM platform. This is inspite of the test running with an env var set to a huge timeout
of 16 minutes. And we are not sure if this is a code issue in the source server which would
otherwise hang indefinitely (but is erroring out due to the 16 minute timeout). So want to run
tests with the env var set to a huge timeout (i.e. days) so a test hang would be signaled by
the test framework and that can be investigated while the source server process is alive.
The only issue with that approach is that the test framework currently resets this env var
unconditionally at test startup even though it was set coming in. That is fixed now.