### PR TITLE
Fix rare v62001/gtm8094pipproc subtest failures due to missing syslog message

### DIFF
--- a/v62001/outref/gtm8094pipproc.txt
+++ b/v62001/outref/gtm8094pipproc.txt
@@ -1,20 +1,16 @@
 Case 1: Prevent dup2() of stdin in forked piped process
 
-Message Found!
-
 Case 2: Prevent dup2() of stdout in forked piped process
-
-Message Found!
 
 Case 3: Prevent dup2() of stderr in forked piped process
 
-Message Found!
-
 Case 4: Prevent second dup2() of stderr in forked piped process
-
-
-Message Found!
 
 Case 5: Prevent EXEC() by the forked piped process
 
-Message Found!
+# See if there was one PIPE message in syslog for each Case above. List of messages follows
+%YDB-E-DEVOPENFAIL, Error opening uname, %YDB-I-TEXT, PIPE - dup2(pfd_write[0]) failed in child, %SYSTEM-E-UNKNOWN, Unknown system error 0
+%YDB-E-DEVOPENFAIL, Error opening uname, %YDB-I-TEXT, PIPE - dup2(pfd_read[1],1) failed in child, %SYSTEM-E-UNKNOWN, Unknown system error 0
+%YDB-E-DEVOPENFAIL, Error opening uname, %YDB-I-TEXT, PIPE - dup2(pfd_read[1],2) failed in child, %SYSTEM-E-UNKNOWN, Unknown system error 0
+%YDB-E-DEVOPENFAIL, Error opening uname, %YDB-I-TEXT, PIPE - dup2(pfd_read_stderr[1],2) failed in child, %SYSTEM-E-UNKNOWN, Unknown system error 0
+%YDB-E-DEVOPENFAIL, Error opening uname, %YDB-I-TEXT, PIPE - execl() failed in child, %SYSTEM-E-UNKNOWN, Unknown system error 0

--- a/v62001/u_inref/gtm8094pipproc.csh
+++ b/v62001/u_inref/gtm8094pipproc.csh
@@ -1,7 +1,10 @@
 #!/usr/local/bin/tcsh -f
 #################################################################
 #								#
-#	Copyright 2014 Fidelity Information Services, Inc	#
+# Copyright 2014 Fidelity Information Services, Inc		#
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
@@ -10,98 +13,45 @@
 #								#
 #################################################################
 
+set syslog_time1 = `date +"%b %e %H:%M:%S"`
+
 # Let's prevent dup2() of stdin in forked piped process
 echo "Case 1: Prevent dup2() of stdin in forked piped process"
 setenv gtm_white_box_test_case_enable 1
 setenv gtm_white_box_test_case_number 109
 
-set syslog_time1 = `date +"%b %e %H:%M:%S"`
-
 $gtm_dist/mumps -run defaultstderr^pipeuname
-
-set syslog_time2 = `date +"%b %e %H:%M:%S"`
-$gtm_tst/com/getoper.csh "$syslog_time1" "$syslog_time2" msgs1.txt "" "PIPE -"
-$grep "PIPE -" msgs1.txt >& grepmsgs.txt
-if (! $status ) then
-	echo "Message Found!"
-else
-	echo "Message Not Found!"
-endif
-echo ""
-
 
 # Let's prevent dup2() of stdout in forked piped process
 echo "Case 2: Prevent dup2() of stdout in forked piped process"
 setenv gtm_white_box_test_case_enable 1
 setenv gtm_white_box_test_case_number 110
 
-set syslog_time1 = `date +"%b %e %H:%M:%S"`
-
 $gtm_dist/mumps -run defaultstderr^pipeuname
-
-set syslog_time2 = `date +"%b %e %H:%M:%S"`
-$gtm_tst/com/getoper.csh "$syslog_time1" "$syslog_time2" msgs2.txt "" "PIPE -"
-$grep "PIPE -" msgs2.txt >& grepmsgs.txt
-if (! $status ) then
-	echo "Message Found!"
-else
-	echo "Message Not Found!"
-endif
-echo ""
 
 # Let's prevent first dup2() of stderr in forked piped process
 echo "Case 3: Prevent dup2() of stderr in forked piped process"
 setenv gtm_white_box_test_case_enable 1
 setenv gtm_white_box_test_case_number 111
 
-set syslog_time1 = `date +"%b %e %H:%M:%S"`
-
 $gtm_dist/mumps -run defaultstderr^pipeuname
-
-set syslog_time2 = `date +"%b %e %H:%M:%S"`
-$gtm_tst/com/getoper.csh "$syslog_time1" "$syslog_time2" msgs3.txt "" "PIPE -"
-$grep "PIPE -" msgs3.txt >& grepmsgs.txt
-if (! $status ) then
-	echo "Message Found!"
-else
-	echo "Message Not Found!"
-endif
-echo ""
 
 # Let's prevent first dup2() of stderr in forked piped process
 echo "Case 4: Prevent second dup2() of stderr in forked piped process"
 setenv gtm_white_box_test_case_enable 1
 setenv gtm_white_box_test_case_number 112
 
-set syslog_time1 = `date +"%b %e %H:%M:%S"`
-
 $gtm_dist/mumps -run assignstderr^pipeuname
-
-set syslog_time2 = `date +"%b %e %H:%M:%S"`
-$gtm_tst/com/getoper.csh "$syslog_time1" "$syslog_time2" msgs4.txt "" "PIPE -"
-$grep "PIPE -" msgs4.txt >& grepmsgs.txt
-echo ""
-if (! $status ) then
-	echo "Message Found!"
-else
-	echo "Message Not Found!"
-endif
-echo ""
 
 # Let's prevent the EXEC() by the forked piped process
 echo "Case 5: Prevent EXEC() by the forked piped process"
 setenv gtm_white_box_test_case_enable 1
 setenv gtm_white_box_test_case_number 113
 
-set syslog_time1 = `date +"%b %e %H:%M:%S"`
-
 $gtm_dist/mumps -run defaultstderr^pipeuname
 
-set syslog_time2 = `date +"%b %e %H:%M:%S"`
-$gtm_tst/com/getoper.csh "$syslog_time1" "$syslog_time2" msgs5.txt "" "PIPE -"
-$grep "PIPE -" msgs5.txt >& grepmsgs.txt
-if (! $status ) then
-	echo "Message Found!"
-else
-	echo "Message Not Found!"
-endif
+echo "# See if there was one PIPE message in syslog for each Case above. List of messages follows"
+$gtm_tst/com/getoper.csh "$syslog_time1" "" msgs.txt
+$grep "PIPE -" msgs.txt | sed 's/.*\(%YDB-E-DEVOPENFAIL\)/\1/;s/ -- generated.*//'
+
+unsetenv gtm_white_box_test_case_enable


### PR DESCRIPTION
We saw a failure in internal testing. Below is the actual output.
```
Expected output
---------------
Case 1: Prevent dup2() of stdin in forked piped process
Message Found!

Actual output
-------------
Case 1: Prevent dup2() of stdin in forked piped process
Message Not Found!
```
The syslog message was not seen in the Case 1.
```
$ cat msgs1.txt
-- Logs begin at Wed 2017-10-25 14:32:59 EDT, end at Tue 2018-07-10 16:59:22 EDT. --
-- No entries --
```
But it was seen in the syslog_gtm8094pipproc.txt file that is created at the end of the subtest.
```
$ cat syslog_gtm8094pipproc.txt
-- Logs begin at Wed 2017-10-25 14:32:59 EDT, end at Tue 2018-07-10 16:59:24 EDT. --
Jul 10 16:59:23 xxxx YDB-MUMPS[13825]: %YDB-E-DEVOPENFAIL, Error opening uname,
	 %YDB-I-TEXT, PIPE - dup2(pfd_write[0]) failed in child,
	 %SYSTEM-E-UNKNOWN, Unknown system error 0 -- generated from 0x00007F0161CB7122.
```
The time of delivery of the syslog message in syslog_gtm8094pipproc.txt is 16:59:23 whereas the
end time in msgs1.txt is 16:59:22. This means the syslog message was on its way to being
delivered when the getoper.csh call (that created msgs1.txt) was done but made it 1 second later.

To avoid such in-transit issues, we can use getoper.csh with $2 == "" which will cause getoper.csh
to send a syslog message (with a random string in it) and wait for that to show up which would
guarantee all previous messages have shown up too.

Additionally, to avoid multiple getoper.csh calls, it is done once at the end of the script. That
is okay since the syslog message corresponding to each test case has a unique message text.