### PR TITLE
Gtm8694 test failure fixes

### DIFF
--- a/v63002/inref/gtm8694.m
+++ b/v63002/inref/gtm8694.m
@@ -60,7 +60,8 @@ zcmdlnefn
 zeditfn
 	write "# TESTING ZEDIT",!
 	set $etrap="do incrtrap^incrtrap"
-	zedit "dummy.txt"
+	set dir=$ZDIRECTORY
+	zedit dir_"/dummy.txt"
 	quit
 
 zsystemfn

--- a/v63002/inref/gtm8694.m
+++ b/v63002/inref/gtm8694.m
@@ -60,8 +60,7 @@ zcmdlnefn
 zeditfn
 	write "# TESTING ZEDIT",!
 	set $etrap="do incrtrap^incrtrap"
-	set dir=$ZDIRECTORY
-	zedit dir_"/dummy.txt"
+	zedit "dummy.txt"
 	quit
 
 zsystemfn

--- a/v63002/outref/gtm8694.txt
+++ b/v63002/outref/gtm8694.txt
@@ -9,7 +9,7 @@ Zbreak command successfully ignored
 # TESTING ZCMDLINE
 
 # TESTING ZEDIT
-ZSTATUS=zeditfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
+ZSTATUS=zeditfn+4^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
 # TESTING ZSYSTEM
 ZSTATUS=zsystemfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZSYSTEM
 # TESTING PIPE
@@ -39,7 +39,7 @@ Zbreak command successfully ignored
 # TESTING ZCMDLINE
 
 # TESTING ZEDIT
-ZSTATUS=zeditfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
+ZSTATUS=zeditfn+4^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
 # TESTING ZSYSTEM
 ZSTATUS=zsystemfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZSYSTEM
 # TESTING PIPE
@@ -68,9 +68,7 @@ ZBREAK not ignored
 # TESTING ZCMDLINE
 ZCMDLNE was not ignored
 # TESTING ZEDIT
-[Using open mode]
-
-Open and visual must be used interactively
+ZEDIT not ignored
 # TESTING ZSYSTEM
 ZSYSTEM not ignored
 # TESTING PIPE
@@ -114,9 +112,7 @@ ZBREAK not ignored
 # TESTING ZCMDLINE
 ZCMDLNE was not ignored
 # TESTING ZEDIT
-[Using open mode]
-
-Open and visual must be used interactively
+ZEDIT not ignored
 # TESTING ZSYSTEM
 ZSYSTEM not ignored
 # TESTING PIPE

--- a/v63002/u_inref/gtm8694.csh
+++ b/v63002/u_inref/gtm8694.csh
@@ -126,15 +126,21 @@ TRIGGER_MOD:$groupname
 EOF
 chmod -w $ydb_dist/restrict.txt
 $gtm_tst/com/lsminusl.csh $ydb_dist/restrict.txt | $tst_awk '{print $1,$9}'
-setenv EDITOR ""
+set sedpath=`which sed`
+setenv EDITOR $sedpath
 $ydb_dist/mumps -run breakfn^gtm8694 >& unrestrictedBREAK.txt
 cat unrestrictedBREAK.txt
 $ydb_dist/mumps -run zbreakfn^gtm8694 >& unrestrictedZBREAK.txt
 cat unrestrictedZBREAK.txt
 $ydb_dist/mumps -run zcmdlnefn^gtm8694 "ZCMDLNE was not ignored" >& unrestrictedZCMDLINE.txt
 cat unrestrictedZCMDLINE.txt
+echo "# TESTING ZEDIT"
 $ydb_dist/mumps -run zeditfn^gtm8694 >& unrestrictedZEDIT.txt
-cat unrestrictedZEDIT.txt
+if ("" == `$grep RESTRICTEDOP unrestrictedZEDIT.txt`) then
+	echo "ZEDIT not ignored"
+else
+	$grep RESTRICTEDOP unrestrictedZEDIT.txt
+endif
 $ydb_dist/mumps -run zsystemfn^gtm8694 >& unrestrictedZSYSTEM.txt
 cat unrestrictedZSYSTEM.txt
 $ydb_dist/mumps -run pipefn^gtm8694 >& unrestrictedPIPE_OPEN.txt
@@ -171,7 +177,13 @@ $gtm_tst/com/lsminusl.csh $ydb_dist/restrict.txt | $tst_awk '{print $1,$9}'
 $ydb_dist/mumps -run breakfn^gtm8694
 $ydb_dist/mumps -run zbreakfn^gtm8694
 $ydb_dist/mumps -run zcmdlnefn^gtm8694 "ZCMDLNE was not ignored"
-$ydb_dist/mumps -run zeditfn^gtm8694
+$ydb_dist/mumps -run zeditfn^gtm8694 >>& zeditoutput.out
+echo "# TESTING ZEDIT"
+if ("" == `$grep RESTRICTEDOP zeditoutput.out`) then
+	echo "ZEDIT not ignored"
+else
+	$grep RESTRICTEDOP zeditoutput.out
+endif
 $ydb_dist/mumps -run zsystemfn^gtm8694
 $ydb_dist/mumps -run pipefn^gtm8694
 $ydb_dist/mumps -run trigmodfn^gtm8694


### PR DESCRIPTION
Moves output of zedit tests to a file and checks for a RESTRICTEDOP error to standardize the test output