### PR TITLE
Test failure fixes for gtm8844

### DIFF
--- a/v63003/u_inref/gtm8844.csh
+++ b/v63003/u_inref/gtm8844.csh
@@ -74,6 +74,7 @@ $MSR START INST1 INST2 >>& MSRStart.out
 
 # Creating initial values for global variables X and Y, uploading triggers
 $MSR RUN INST1 '$ydb_dist/mumps -run ^%XCMD "set ^X=0  set ^Y=0"'
+$MSR SYNC INST1 INST2 >>& waitforupdate.outx
 $MUPIP trigger -triggerfile=trigger.txt
 
 echo ""


### PR DESCRIPTION
Fix the issue where the first update does not get replicated by the secondary before the rest of the processes begin