### PR TITLE
New v63004/gtm8900 subtest (tests GTM-8900 in V63004)

### DIFF
--- a/v63004/outref/gtm8900.txt
+++ b/v63004/outref/gtm8900.txt
@@ -1,0 +1,29 @@
+# Create a single region DB with region DEFAULT
+# Check the DB
+
+# Testing MUPIP SET -[NO]ENCRYPT in a properly set up environment
+# --------------------------------------------------------------------------
+# \##SOURCE_PATH##/mupip set -ENCRYPTABLE -REGION 'DEFAULT'
+Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to  TRUE
+
+# \##SOURCE_PATH##/mupip set -NOENCRYPTABLE -REGION 'DEFAULT'
+Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE
+
+
+# Testing MUPIP SET -ENCRYPT  with no set gtm_passwd (expecting failure)
+# --------------------------------------------------------------------------
+# \##SOURCE_PATH##/mupip set -ENCRYPTABLE -REGION 'DEFAULT'
+%YDB-E-CRYPTINIT2, Could not initialize encryption library during GT.M startup. Environment variable ydb_passwd/gtm_passwd not set
+
+# \##SOURCE_PATH##/mupip set -NOENCRYPTABLE -REGION 'DEFAULT'
+Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE
+
+
+# Testing MUPIP SET -ENCRYPT  with garbage GNUPGHOME (expecting failure)
+# --------------------------------------------------------------------------
+GNUPGHOME: garbageValue
+# \##SOURCE_PATH##/mupip set -ENCRYPTABLE -REGION 'DEFAULT'
+%YDB-E-CRYPTINIT2, Could not initialize encryption library during GT.M startup. Cannot stat on garbageValue - 2
+
+# \##SOURCE_PATH##/mupip set -NOENCRYPTABLE -REGION 'DEFAULT'
+Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE

--- a/v63004/outref/gtm8900.txt
+++ b/v63004/outref/gtm8900.txt
@@ -2,7 +2,7 @@
 # Check the DB
 
 # Testing MUPIP SET -[NO]ENCRYPT in a properly set up environment
-# --------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------------------------
 # \##SOURCE_PATH##/mupip set -ENCRYPTABLE -REGION 'DEFAULT'
 Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to  TRUE
 
@@ -10,8 +10,8 @@ Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to  TRUE
 Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE
 
 
-# Testing MUPIP SET -ENCRYPT  with no set gtm_passwd (expecting failure)
-# --------------------------------------------------------------------------
+# Testing MUPIP SET -[NO]ENCRYPT  with no set gtm_passwd (expecting failure for ENCRYPT and success for NOENCRYPT)
+# --------------------------------------------------------------------------------------------------------------------
 # \##SOURCE_PATH##/mupip set -ENCRYPTABLE -REGION 'DEFAULT'
 %YDB-E-CRYPTINIT2, Could not initialize encryption library during GT.M startup. Environment variable ydb_passwd/gtm_passwd not set
 
@@ -19,11 +19,21 @@ Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE
 Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE
 
 
-# Testing MUPIP SET -ENCRYPT  with garbage GNUPGHOME (expecting failure)
-# --------------------------------------------------------------------------
+# Testing MUPIP SET -[NO]ENCRYPT  with set garbage GNUPGHOME (expecting failure for ENCRYPT and success for NOENCRYPT)
+# --------------------------------------------------------------------------------------------------------------------
 GNUPGHOME: garbageValue
 # \##SOURCE_PATH##/mupip set -ENCRYPTABLE -REGION 'DEFAULT'
 %YDB-E-CRYPTINIT2, Could not initialize encryption library during GT.M startup. Cannot stat on garbageValue - 2
 
+# \##SOURCE_PATH##/mupip set -NOENCRYPTABLE -REGION 'DEFAULT'
+Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE
+
+
+# Testing MUPIP SET -[NO]ENCRYPT  with encryptable flag set true and GNUPGHOME and gtm_passwd is randomly set
+# --------------------------------------------------------------------------------------------------------------------
+# \##SOURCE_PATH##/mupip set -ENCRYPTABLE -REGION 'DEFAULT'
+Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to  TRUE
+##TEST_AWK^#.*GNUPGHOME.*
+##TEST_AWK^#.*gtm_passwd.*
 # \##SOURCE_PATH##/mupip set -NOENCRYPTABLE -REGION 'DEFAULT'
 Database file ##TEST_PATH##/mumps.dat now has encryptable flag set to FALSE

--- a/v63004/u_inref/gtm8900.csh
+++ b/v63004/u_inref/gtm8900.csh
@@ -1,0 +1,41 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+
+echo "# Create a single region DB with region DEFAULT"
+$gtm_tst/com/dbcreate.csh mumps >>& dbcreate_log.txt
+if ($status) then
+	echo "DB Create Failed, Output Below"
+	cat dbcreate_log.txt
+endif
+
+echo "# \$MUPIP set -ENCRYPTABLE -region="DEFAULT""
+$MUPIP set -ENCRYPTABLE -region="DEFAULT"
+$MUPIP set -ENCRYPTABLE -file="mumps.dat"
+#These errors seems to be unrelated to the reasons for failure described in the patch
+#%YDB-E-CLIERR, Assignment is not allowed for this option : REGION
+#%YDB-E-CLIERR, Assignment is not allowed for this option : FILE
+
+echo "# \$MUPIP set -NOENCRYPTABLE -region="DEFAULT""
+$MUPIP set -NOENCRYPTABLE -region="DEFAULT"
+$MUPIP set -NOENCRYPTABLE -file="mumps.dat"
+#These errors seems to be unrelated to the reasons for failure described in the patch
+#%YDB-E-CLIERR, Assignment is not allowed for this option : REGION
+#%YDB-E-CLIERR, Assignment is not allowed for this option : FILE
+
+$gtm_tst/com/dbcheck.csh >>& dbcheck_log.txt
+if ($status) then
+	echo "DB Check Failed, Output Below"
+	cat dbcheck_log.txt
+endif
+

--- a/v63004/u_inref/gtm8900.csh
+++ b/v63004/u_inref/gtm8900.csh
@@ -32,7 +32,8 @@ echo ""
 
 echo "# Testing MUPIP SET -[NO]ENCRYPT in a properly set up environment"
 echo "# --------------------------------------------------------------------------"
-setenv gtm_passwd "1AF39D" # Garbage string in hexidecimal format (hex is required for this env var)
+setenv gtm_passwd "48657920796f7520666f756e64206d79207365637265742120676f6f64206a6f6221" # Garbage string in hexidecimal format (hex is required for this env var)
+
 
 echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
 $MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
@@ -54,7 +55,7 @@ echo ""
 echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
 $MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
 
-setenv gtm_passwd "1AF39D" # Garbage string in hexidecimal format (hex is required for this env var)
+setenv gtm_passwd "4a616b652052657a616320372f31312f32303138" # Garbage string in hexidecimal format (hex is required for this env var)
 
 echo ""
 echo ""

--- a/v63004/u_inref/gtm8900.csh
+++ b/v63004/u_inref/gtm8900.csh
@@ -31,8 +31,10 @@ echo ""
 
 
 echo "# Testing MUPIP SET -[NO]ENCRYPT in a properly set up environment"
-echo "# --------------------------------------------------------------------------"
-setenv gtm_passwd "48657920796f7520666f756e64206d79207365637265742120676f6f64206a6f6221" # Garbage string in hexidecimal format (hex is required for this env var)
+echo "# --------------------------------------------------------------------------------------------------------------------"
+#setenv gtm_passwd "69747320612073656372657420746f206576657279626f6479a" # Garbage string in hexidecimal format (hex is required for this env var)
+setenv gtm_passwd "69747320612073656372657420746f206576657279626f647921" # Garbage string in hexidecimal format (hex is required for this env var)
+
 
 
 echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
@@ -45,8 +47,8 @@ echo ""
 echo ""
 
 
-echo "# Testing MUPIP SET -ENCRYPT  with no set gtm_passwd (expecting failure)"
-echo "# --------------------------------------------------------------------------"
+echo "# Testing MUPIP SET -[NO]ENCRYPT  with no set gtm_passwd (expecting failure for ENCRYPT and success for NOENCRYPT)"
+echo "# --------------------------------------------------------------------------------------------------------------------"
 unsetenv gtm_passwd
 
 echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
@@ -61,8 +63,8 @@ echo ""
 echo ""
 
 
-echo "# Testing MUPIP SET -ENCRYPT  with garbage GNUPGHOME (expecting failure)"
-echo "# --------------------------------------------------------------------------"
+echo "# Testing MUPIP SET -[NO]ENCRYPT  with set garbage GNUPGHOME (expecting failure for ENCRYPT and success for NOENCRYPT)"
+echo "# --------------------------------------------------------------------------------------------------------------------"
 setenv GNUPGHOME "garbageValue"
 echo "GNUPGHOME: $GNUPGHOME"
 
@@ -74,8 +76,44 @@ $MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
 
 unsetenv GNUPGHOME
 
+echo ""
+echo ""
+
+
+#Add a test for $MUPIP SET -NOENCRYPT where:
+#		- encryptable flag is set to true
+#		- GNUPGHOME randomly set to garbage or not
+#		- gtm_passwd is randomly set or not set
+echo "# Testing MUPIP SET -[NO]ENCRYPT  with encryptable flag set true and GNUPGHOME and gtm_passwd is randomly set"
+echo "# --------------------------------------------------------------------------------------------------------------------"
+
+setenv set_GNUPGHOME `$gtm_tst/com/genrandnumbers.csh`
+setenv set_gtm_passwd `$gtm_tst/com/genrandnumbers.csh`
+
+echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
+
+if ($set_GNUPGHOME) then
+	setenv GNUPGHOME "garbageValue"
+	echo "#		GNUPGHOME set to $GNUPGHOME"
+else
+	echo "# 	GNUPGHOME left unset"
+endif
+
+if ($set_gtm_passwd) then
+	setenv gtm_passwd "726f736574796c65726d61727468616a6f6e6573646f6e6e616e6f62656c544152444953" # Garbage string in hexidecimal format (hex is required for this env var)
+	echo "#		gtm_passwd set to garbage value"
+else
+	unsetenv gtm_passwd
+	echo "#		gtm_passwd unset"
+endif
+
+echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP SET -NOENCRYPTABLE -REGION "DEFAULT"
+
+
 # The following block is meant to test for failure when GNUPGHOME is set to a real
-# directory that is still invalide. However, MUPIP SET -[NO]ENCRYPTABLE still works.
+# directory that is still invalid. However, MUPIP SET -[NO]ENCRYPTABLE still works.
 # It is believed that this is due to a minsunderstanding with the patch notes.
 # It is very possible that "invalid directory" simply means "non-existent directory"
 

--- a/v63004/u_inref/gtm8900.csh
+++ b/v63004/u_inref/gtm8900.csh
@@ -80,7 +80,7 @@ unsetenv GNUPGHOME
 # It is very possible that "invalid directory" simply means "non-existent directory"
 
 #echo "# Testing MUPIP SET -[NO]ENCRYPT  with improper GNUPGHOME (expecting failure)"
-#echo "# --------------------------------------------------------------------------"
+#echo "# ---------------------------------------------------------------------------"
 #mkdir temp
 #setenv GNUPGHOME "./temp"
 #echo "GNUPGHOME: $GNUPGHOME"

--- a/v63004/u_inref/gtm8900.csh
+++ b/v63004/u_inref/gtm8900.csh
@@ -87,6 +87,8 @@ echo ""
 echo "# Testing MUPIP SET -[NO]ENCRYPT  with encryptable flag set true and GNUPGHOME and gtm_passwd is randomly set"
 echo "# --------------------------------------------------------------------------------------------------------------------"
 
+#These randomly set variables (either 0 or 1) will be used to choose whether or not to set
+#GNUPGHOME and gtm_passwd respectively.
 setenv set_GNUPGHOME `$gtm_tst/com/genrandnumbers.csh`
 setenv set_gtm_passwd `$gtm_tst/com/genrandnumbers.csh`
 

--- a/v63004/u_inref/gtm8900.csh
+++ b/v63004/u_inref/gtm8900.csh
@@ -11,6 +11,8 @@
 #								#
 #################################################################
 #
+setenv gtm_test_mupip_set_version "disable" # Encryption cannot work on V4 databases.
+setenv acc_meth BG # MM and encryption is not supported
 
 echo "# Create a single region DB with region DEFAULT"
 $gtm_tst/com/dbcreate.csh mumps >>& dbcreate_log.txt
@@ -25,24 +27,67 @@ if ($status) then
 	echo "DB Check Failed, Output Below"
 	cat dbcheck_log.txt
 endif
+echo ""
 
 
-setenv gtm_passwd "1AF39D"
+echo "# Testing MUPIP SET -[NO]ENCRYPT in a properly set up environment"
+echo "# --------------------------------------------------------------------------"
+setenv gtm_passwd "1AF39D" # Garbage string in hexidecimal format (hex is required for this env var)
 
 echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
 $MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
 echo ""
-
 echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
 $MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
+
+echo ""
 echo ""
 
-#unsetenv gtm_passwd
+
+echo "# Testing MUPIP SET -ENCRYPT  with no set gtm_passwd (expecting failure)"
+echo "# --------------------------------------------------------------------------"
+unsetenv gtm_passwd
+
+echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
+echo ""
+echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
+
+setenv gtm_passwd "1AF39D" # Garbage string in hexidecimal format (hex is required for this env var)
+
+echo ""
+echo ""
+
+
+echo "# Testing MUPIP SET -ENCRYPT  with garbage GNUPGHOME (expecting failure)"
+echo "# --------------------------------------------------------------------------"
+setenv GNUPGHOME "garbageValue"
+echo "GNUPGHOME: $GNUPGHOME"
+
+echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
+echo ""
+echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
+
+unsetenv GNUPGHOME
+
+# The following block is meant to test for failure when GNUPGHOME is set to a real
+# directory that is still invalide. However, MUPIP SET -[NO]ENCRYPTABLE still works.
+# It is believed that this is due to a minsunderstanding with the patch notes.
+# It is very possible that "invalid directory" simply means "non-existent directory"
+
+#echo "# Testing MUPIP SET -[NO]ENCRYPT  with improper GNUPGHOME (expecting failure)"
+#echo "# --------------------------------------------------------------------------"
+#mkdir temp
+#setenv GNUPGHOME "./temp"
+#echo "GNUPGHOME: $GNUPGHOME"
 #
 #echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
 #$MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
 #echo ""
-#
 #echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
 #$MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
+#echo ""
 #echo ""

--- a/v63004/u_inref/gtm8900.csh
+++ b/v63004/u_inref/gtm8900.csh
@@ -19,23 +19,30 @@ if ($status) then
 	cat dbcreate_log.txt
 endif
 
-echo "# \$MUPIP set -ENCRYPTABLE -region="DEFAULT""
-$MUPIP set -ENCRYPTABLE -region="DEFAULT"
-$MUPIP set -ENCRYPTABLE -file="mumps.dat"
-#These errors seems to be unrelated to the reasons for failure described in the patch
-#%YDB-E-CLIERR, Assignment is not allowed for this option : REGION
-#%YDB-E-CLIERR, Assignment is not allowed for this option : FILE
-
-echo "# \$MUPIP set -NOENCRYPTABLE -region="DEFAULT""
-$MUPIP set -NOENCRYPTABLE -region="DEFAULT"
-$MUPIP set -NOENCRYPTABLE -file="mumps.dat"
-#These errors seems to be unrelated to the reasons for failure described in the patch
-#%YDB-E-CLIERR, Assignment is not allowed for this option : REGION
-#%YDB-E-CLIERR, Assignment is not allowed for this option : FILE
-
+echo "# Check the DB"
 $gtm_tst/com/dbcheck.csh >>& dbcheck_log.txt
 if ($status) then
 	echo "DB Check Failed, Output Below"
 	cat dbcheck_log.txt
 endif
 
+
+setenv gtm_passwd "1AF39D"
+
+echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
+echo ""
+
+echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
+$MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
+echo ""
+
+#unsetenv gtm_passwd
+#
+#echo "# \$MUPIP set -ENCRYPTABLE -REGION 'DEFAULT'"
+#$MUPIP SET -ENCRYPTABLE -REGION "DEFAULT"
+#echo ""
+#
+#echo "# \$MUPIP set -NOENCRYPTABLE -REGION 'DEFAULT'"
+#$MUPIP set -NOENCRYPTABLE -REGION "DEFAULT"
+#echo ""


### PR DESCRIPTION
Tests the following release note

MUPIP SET -NOENCRYPTABLE can set the database encryptable flag to FALSE. Previously, after invoking MUPIP SET -ENCRYPTABLE attempting to undo that action failed unless the GNUPGHOME pointed to a valid directory and gtm_passwd was defined in the environment. This issue was only observed in the GT.M development environment, and was never reported by a user. MUPIP SET -ENCRYPTABLE now performs some basic encryption setup checks. To execute this command, GNUPGHOME must point to a valid directory and gtm_passwd must be defined in the environment. Previously, the command did not require these environment variables. (GTM-8900)