### PR TITLE
Fixed test failure for gtm8694

### DIFF
--- a/v63002/outref/gtm8694.txt
+++ b/v63002/outref/gtm8694.txt
@@ -9,7 +9,7 @@ Zbreak command successfully ignored
 # TESTING ZCMDLINE
 
 # TESTING ZEDIT
-ZSTATUS=zeditfn+4^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
+ZSTATUS=zeditfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
 # TESTING ZSYSTEM
 ZSTATUS=zsystemfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZSYSTEM
 # TESTING PIPE
@@ -39,7 +39,7 @@ Zbreak command successfully ignored
 # TESTING ZCMDLINE
 
 # TESTING ZEDIT
-ZSTATUS=zeditfn+4^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
+ZSTATUS=zeditfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZEDIT
 # TESTING ZSYSTEM
 ZSTATUS=zsystemfn+3^gtm8694,%YDB-E-RESTRICTEDOP, Attempt to perform a restricted operation: ZSYSTEM
 # TESTING PIPE


### PR DESCRIPTION
Fixed a typo in the reference file of the subtest