### PR TITLE
Fix rare v60001/gtm7461 subtest hang due to a test timing issue

### DIFF
--- a/v60001/outref/gtm7461.txt
+++ b/v60001/outref/gtm7461.txt
@@ -7,7 +7,10 @@
 # stop passive source server
 # stop imptp
 # remove journal files
-# rollback
+# start MUPIP JOURNAL -ROLLBACK -BACKWARD which should trigger instance freeze
+# check syslog to confirm instance freeze related messages (REPLINSTFROZEN/JNLFILEOPNERR) are seen
+%YDB-E-REPLINSTFROZEN, Instance INSTANCE1 is now Frozen
+%YDB-I-REPLINSTFREEZECOMMENT, Freeze Comment: PID xxxx encountered JNLFILEOPNERR; Instance frozen
 # unfreeze and wait
 # final rundown
 # done

--- a/v60001/u_inref/gtm7461.csh
+++ b/v60001/u_inref/gtm7461.csh
@@ -72,28 +72,28 @@ echo "# remove journal files"
 
 $gtm_tst/com/backup_dbjnl.csh "" "*.mjl*" "mv"
 
-echo "# rollback"
+echo "# start MUPIP JOURNAL -ROLLBACK -BACKWARD which should trigger instance freeze"
 
 set syslog_before1 = `date +"%b %e %H:%M:%S"`
 echo "$syslog_before1" > syslog_before1.txt
 
-sleep 2		# Managed to slip out of the getoper window somehow, so give it a couple seconds to be safe.
+sleep 1		# Managed to slip out of the getoper window somehow, so give it a couple seconds to be safe.
 
-# just in case rollback hangs on freeze, run it in the background
-# This relies on the $! being the pid of the rollback process. So pass "-backward" explicitly as otherwise a hidden
-# "-forward" rollback is attempted by the mupip_rollback.csh script and the $! calculations are disturbed.
-($gtm_tst/com/mupip_rollback.csh -backward -resync=10000 '*' >& rollback.outx & ; echo $! > rollback_pid.txt) >& /dev/null
+# do not use mupip_rollback.csh since we want to know the rollback pid which is not possible if we use a wrapper script
+($MUPIP journal -rollback -backward -resync=10000 '*' >& rollback.outx & ; echo $! > rollback_pid.txt) >& /dev/null
 
-$gtm_tst/com/getoper.csh "$syslog_before1" "" syslog1.txt "" "REPLINSTFROZEN"
-$gtm_tst/com/getoper.csh "$syslog_before1" "" syslog2.txt "" "encountered JNLFILEOPNERR"
+set rollbackpid = `cat rollback_pid.txt`
+$gtm_tst/com/wait_for_proc_to_die.csh $rollbackpid
+
+echo "# check syslog to confirm instance freeze related messages (REPLINSTFROZEN/JNLFILEOPNERR) are seen"
+$gtm_tst/com/getoper.csh "$syslog_before1" "" syslog1.txt
+$grep -E "REPLINSTFROZEN|JNLFILEOPNERR" syslog1.txt | sed 's/.*%YDB/%YDB/;s/ -- .*//' | sed 's/'$rollbackpid'/xxxx/'
 
 echo "# unfreeze and wait"
 $MUPIP replic -source -freeze=off >&! freeze_off.outx
 
 # YDB-E-NOJNLPOOL can occur if an argumentless rundown is done by some other test in this timeframe
 $grep -v 'YDB-E-NOJNLPOOL' freeze_off.outx
-
-$gtm_tst/com/wait_for_proc_to_die.csh `cat rollback_pid.txt`
 
 echo "# final rundown"
 

--- a/v60001/u_inref/gtm7461.csh
+++ b/v60001/u_inref/gtm7461.csh
@@ -77,7 +77,7 @@ echo "# start MUPIP JOURNAL -ROLLBACK -BACKWARD which should trigger instance fr
 set syslog_before1 = `date +"%b %e %H:%M:%S"`
 echo "$syslog_before1" > syslog_before1.txt
 
-sleep 1		# Managed to slip out of the getoper window somehow, so give it a couple seconds to be safe.
+sleep 1		# Managed to slip out of the getoper window somehow, so give it a second to be safe.
 
 # do not use mupip_rollback.csh since we want to know the rollback pid which is not possible if we use a wrapper script
 ($MUPIP journal -rollback -backward -resync=10000 '*' >& rollback.outx & ; echo $! > rollback_pid.txt) >& /dev/null


### PR DESCRIPTION
In an in-house test run, we had a test hang. This was because the instance got frozen
(by the backgrounded "mupip journal -rollback -backward" process) due to the JNLFILEOPNERR error
AFTER the foreground test script had unfreezed the instance resulting in a later call to
mupip rundown hanging due to the instance freeze active at that point.

The test flow has now been fixed so we wait for the backgrounded rollback to finish before
getting the syslog messages. We now confirm the REPLINSTFROZEN and JNLFILEOPNERR messages are
seen and include the actual message in the reference file.