### PR TITLE
Fixed Subtest Failure for v63002/gtm8644

### DIFF
--- a/v63002/outref/gtm8616.txt
+++ b/v63002/outref/gtm8616.txt
@@ -1,6 +1,6 @@
 # Running argumentless MUPIP RUNDOWN and checking syslog
 
 # Syslog message:
-##TEST_AWK%YDB-I-MURNDWNARGLESS, Argumentless MUPIP RUNDOWN started with process id [0-9]* by userid [0-9]* from directory ##TEST_PATH##/ -- generated from 0x.................
+##TEST_AWK%YDB-I-MURNDWNARGLESS, Argumentless MUPIP RUNDOWN started with process id [0-9]* by userid [0-9]* from directory ##TEST_PATH##/ -- generated from 0x.*
 # User ID in syslog message correct
 # PID in syslog message correct


### PR DESCRIPTION
We occasionally saw test failures with the following diff

```
< ##DIFFERENT EXPRESSION##^%YDB-I-MURNDWNARGLESS, Argumentless MUPIP RUNDOWN started with process id [0-9]* by userid [0-9]* from directory /extra/testarea1/nars/V998/tst_V998_R122_dbg_07_180716_170142/v63002_0_1/gtm8616/ -- generated from 0x.................$## VS ##%YDB-I-MURNDWNARGLESS, Argumentless MUPIP RUNDOWN started with process id 28140 by userid 228 from directory /extra/testarea1/nars/V998/tst_V998_R122_dbg_07_180716_170142/v63002_0_1/gtm8616/ -- generated from 0x76003588.##
---
> %YDB-I-MURNDWNARGLESS, Argumentless MUPIP RUNDOWN started with process id 28140 by userid 228 from directory /extra/testarea1/nars/V998/tst_V998_R122_dbg_07_180716_170142/v63002_0_1/gtm8616/ -- generated from 0x76003588
```

Subtest would fail because in reference file, we generalized one hex key to be 16 characters, but this key would be 8 characters on other boxes. To account for this, I generalized the key to be any number of characters