### PR TITLE
Fix v60001/gtm7461 test failures due to unrelated REPLINSTFROZEN messages

### DIFF
--- a/v60001/outref/gtm7461.txt
+++ b/v60001/outref/gtm7461.txt
@@ -8,7 +8,7 @@
 # stop imptp
 # remove journal files
 # start MUPIP JOURNAL -ROLLBACK -BACKWARD which should trigger instance freeze
-# check syslog to confirm instance freeze related messages (REPLINSTFROZEN/JNLFILEOPNERR) are seen
+# check syslog to confirm instance freeze related messages (REPLINSTFROZEN/JNLFILEOPNERR) are seen from the rollback pid
 %YDB-E-REPLINSTFROZEN, Instance INSTANCE1 is now Frozen
 %YDB-I-REPLINSTFREEZECOMMENT, Freeze Comment: PID xxxx encountered JNLFILEOPNERR; Instance frozen
 # unfreeze and wait

--- a/v60001/u_inref/gtm7461.csh
+++ b/v60001/u_inref/gtm7461.csh
@@ -85,9 +85,11 @@ sleep 1		# Managed to slip out of the getoper window somehow, so give it a secon
 set rollbackpid = `cat rollback_pid.txt`
 $gtm_tst/com/wait_for_proc_to_die.csh $rollbackpid
 
-echo "# check syslog to confirm instance freeze related messages (REPLINSTFROZEN/JNLFILEOPNERR) are seen"
+echo "# check syslog to confirm instance freeze related messages (REPLINSTFROZEN/JNLFILEOPNERR) are seen from the rollback pid"
 $gtm_tst/com/getoper.csh "$syslog_before1" "" syslog1.txt
-$grep -E "REPLINSTFROZEN|JNLFILEOPNERR" syslog1.txt | sed 's/.*%YDB/%YDB/;s/ -- .*//' | sed 's/'$rollbackpid'/xxxx/'
+# Note that it is possible we see REPLINSTFROZEN messages on both primary and secondary in the syslog
+# whereas we are interested only on the primary side hence the ".*INSTANCE1" usage below.
+$grep -E "\<$rollbackpid\>.*REPLINSTFROZEN|\<$rollbackpid\>.*JNLFILEOPNERR" syslog1.txt | sed 's/.*%YDB/%YDB/;s/ -- .*//' | sed 's/'$rollbackpid'/xxxx/'
 
 echo "# unfreeze and wait"
 $MUPIP replic -source -freeze=off >&! freeze_off.outx

--- a/v60001/u_inref/gtm7461.csh
+++ b/v60001/u_inref/gtm7461.csh
@@ -87,8 +87,6 @@ $gtm_tst/com/wait_for_proc_to_die.csh $rollbackpid
 
 echo "# check syslog to confirm instance freeze related messages (REPLINSTFROZEN/JNLFILEOPNERR) are seen from the rollback pid"
 $gtm_tst/com/getoper.csh "$syslog_before1" "" syslog1.txt
-# Note that it is possible we see REPLINSTFROZEN messages on both primary and secondary in the syslog
-# whereas we are interested only on the primary side hence the ".*INSTANCE1" usage below.
 $grep -E "\<$rollbackpid\>.*REPLINSTFROZEN|\<$rollbackpid\>.*JNLFILEOPNERR" syslog1.txt | sed 's/.*%YDB/%YDB/;s/ -- .*//' | sed 's/'$rollbackpid'/xxxx/'
 
 echo "# unfreeze and wait"


### PR DESCRIPTION
We had two failures in internal testing.

1) We saw a REPLINSTFROZEN message on the INSTANCE2 (secondary) side.
2) We saw a REPLINSTFROZEN message on INSTANCE1 side but from an unrelated test that was running concurrently.

To address both failures, the fix done is to search only for messages coming from the rollback pid
(which the test is already aware of).