### PR TITLE
Fixed occasional v63002/gtm8766 test failure

### DIFF
--- a/v63002/outref/gtm8766.txt
+++ b/v63002/outref/gtm8766.txt
@@ -1,5 +1,5 @@
-##TEST_AWK# In the current version, [0-9]* is the maximum value accepted by both MUPIP and GDE. In previous versions
-##TEST_AWK# [0-9]* was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE
+##TEST_AWK# In the current version, (2Mb|64Kb) is the maximum value accepted by both MUPIP and GDE. In previous versions
+##TEST_AWK# (2Mb|64Kb) was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE
 
 ##TEST_AWK# CHANGING THE BUFFER COUNT TO [0-9]*
 

--- a/v63002/outref/gtm8766.txt
+++ b/v63002/outref/gtm8766.txt
@@ -1,5 +1,5 @@
-##TEST_AWK# In the current version, (2Mb|64Kb) is the maximum value accepted by both MUPIP and GDE. In previous versions
-##TEST_AWK# (2Mb|64Kb) was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE
+##TEST_AWK# In the current version, (2Mb-1|64Kb) .for (64|32) bit builds. is the maximum value accepted by both MUPIP and GDE. In previous versions
+##TEST_AWK# (2Mb-1|64Kb) was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE
 
 ##TEST_AWK# CHANGING THE BUFFER COUNT TO (2097151|65536)
 

--- a/v63002/outref/gtm8766.txt
+++ b/v63002/outref/gtm8766.txt
@@ -1,7 +1,7 @@
-# In the current version, 2MB is the maximum value accepted by both MUPIP and GDE. In previous versions
-# 2MB was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE
+##TEST_AWK# In the current version, [0-9]* is the maximum value accepted by both MUPIP and GDE. In previous versions
+##TEST_AWK# [0-9]* was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE
 
-# CHANGING THE BUFFER COUNT TO 2097151
+##TEST_AWK# CHANGING THE BUFFER COUNT TO [0-9]*
 
 # TEST CHANGING BUFFERCOUNT VIA GDE
 %GDE-I-LOADGD, Loading Global Directory file 
@@ -13,24 +13,24 @@
 %GDE-I-GDUPDATE, Updating Global Directory file 
 	##TEST_PATH##/mumps.gld
 # TEST CHANGING BUFFERCOUNT VIA MUPIP
-Database file ##TEST_PATH##/mumps.dat now has 2097151 global buffers
+##TEST_AWKDatabase file ##TEST_PATH##/mumps.dat now has [0-9]* global buffers
 
 ----------------------------------------------------------------------------------
 
-# CHANGING THE BUFFER COUNT TO 2097152
+##TEST_AWK# CHANGING THE BUFFER COUNT TO [0-9]*
 
 # TEST CHANGING BUFFERCOUNT VIA GDE
 %GDE-I-LOADGD, Loading Global Directory file 
 	##TEST_PATH##/mumps.gld
 %GDE-I-VERIFY, Verification OK
 
-%GDE-I-VALTOOBIG, 2097152 is larger than the maximum of 2097151 for a GLOBAL_BUFFER_COUNT
+##TEST_AWK%GDE-I-VALTOOBIG, [0-9]* is larger than the maximum of [0-9]* for a GLOBAL_BUFFER_COUNT
 %GDE-I-SEGIS, in BG segment DEFAULT
 
 %GDE-E-OBJNOTCHG, Not changing segment DEFAULT
 %GDE-I-NOACTION, Not updating Global Directory ##TEST_PATH##/mumps.gld
 # TEST CHANGING BUFFERCOUNT VIA MUPIP
-%YDB-W-MUPIPSET2BIG, 2097152 too large, maximum GLOBAL_BUFFERS allowed is 2097151
+##TEST_AWK%YDB-W-MUPIPSET2BIG, [0-9]* too large, maximum GLOBAL_BUFFERS allowed is [0-9]*
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 
 ----------------------------------------------------------------------------------
@@ -42,13 +42,13 @@ Database file ##TEST_PATH##/mumps.dat now has 2097151 global buffers
 	##TEST_PATH##/mumps.gld
 %GDE-I-VERIFY, Verification OK
 
-%GDE-I-VALTOOBIG, 2147483647 is larger than the maximum of 2097151 for a GLOBAL_BUFFER_COUNT
+##TEST_AWK%GDE-I-VALTOOBIG, 2147483647 is larger than the maximum of [0-9]* for a GLOBAL_BUFFER_COUNT
 %GDE-I-SEGIS, in BG segment DEFAULT
 
 %GDE-E-OBJNOTCHG, Not changing segment DEFAULT
 %GDE-I-NOACTION, Not updating Global Directory ##TEST_PATH##/mumps.gld
 # TEST CHANGING BUFFERCOUNT VIA MUPIP
-%YDB-W-MUPIPSET2BIG, 2147483647 too large, maximum GLOBAL_BUFFERS allowed is 2097151
+##TEST_AWK%YDB-W-MUPIPSET2BIG, 2147483647 too large, maximum GLOBAL_BUFFERS allowed is [0-9]*
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 
 ----------------------------------------------------------------------------------
@@ -60,7 +60,7 @@ Database file ##TEST_PATH##/mumps.dat now has 2097151 global buffers
 	##TEST_PATH##/mumps.gld
 %GDE-I-VERIFY, Verification OK
 
-%GDE-I-VALTOOBIG, 2147483648 is larger than the maximum of 2097151 for a GLOBAL_BUFFER_COUNT
+##TEST_AWK%GDE-I-VALTOOBIG, 2147483648 is larger than the maximum of [0-9]* for a GLOBAL_BUFFER_COUNT
 %GDE-I-SEGIS, in BG segment DEFAULT
 
 %GDE-E-OBJNOTCHG, Not changing segment DEFAULT

--- a/v63002/outref/gtm8766.txt
+++ b/v63002/outref/gtm8766.txt
@@ -1,7 +1,7 @@
 ##TEST_AWK# In the current version, (2Mb|64Kb) is the maximum value accepted by both MUPIP and GDE. In previous versions
 ##TEST_AWK# (2Mb|64Kb) was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE
 
-##TEST_AWK# CHANGING THE BUFFER COUNT TO [0-9]*
+##TEST_AWK# CHANGING THE BUFFER COUNT TO (2097151|65536)
 
 # TEST CHANGING BUFFERCOUNT VIA GDE
 %GDE-I-LOADGD, Loading Global Directory file 
@@ -13,24 +13,24 @@
 %GDE-I-GDUPDATE, Updating Global Directory file 
 	##TEST_PATH##/mumps.gld
 # TEST CHANGING BUFFERCOUNT VIA MUPIP
-##TEST_AWKDatabase file ##TEST_PATH##/mumps.dat now has [0-9]* global buffers
+##TEST_AWKDatabase file ##TEST_PATH##/mumps.dat now has (2097151|65536) global buffers
 
 ----------------------------------------------------------------------------------
 
-##TEST_AWK# CHANGING THE BUFFER COUNT TO [0-9]*
+##TEST_AWK# CHANGING THE BUFFER COUNT TO (2097152|65537)
 
 # TEST CHANGING BUFFERCOUNT VIA GDE
 %GDE-I-LOADGD, Loading Global Directory file 
 	##TEST_PATH##/mumps.gld
 %GDE-I-VERIFY, Verification OK
 
-##TEST_AWK%GDE-I-VALTOOBIG, [0-9]* is larger than the maximum of [0-9]* for a GLOBAL_BUFFER_COUNT
+##TEST_AWK%GDE-I-VALTOOBIG, (2097152|65537) is larger than the maximum of (2097151|65536) for a GLOBAL_BUFFER_COUNT
 %GDE-I-SEGIS, in BG segment DEFAULT
 
 %GDE-E-OBJNOTCHG, Not changing segment DEFAULT
 %GDE-I-NOACTION, Not updating Global Directory ##TEST_PATH##/mumps.gld
 # TEST CHANGING BUFFERCOUNT VIA MUPIP
-##TEST_AWK%YDB-W-MUPIPSET2BIG, [0-9]* too large, maximum GLOBAL_BUFFERS allowed is [0-9]*
+##TEST_AWK%YDB-W-MUPIPSET2BIG, (2097152|65537) too large, maximum GLOBAL_BUFFERS allowed is (2097151|65536)
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 
 ----------------------------------------------------------------------------------
@@ -42,13 +42,13 @@
 	##TEST_PATH##/mumps.gld
 %GDE-I-VERIFY, Verification OK
 
-##TEST_AWK%GDE-I-VALTOOBIG, 2147483647 is larger than the maximum of [0-9]* for a GLOBAL_BUFFER_COUNT
+##TEST_AWK%GDE-I-VALTOOBIG, 2147483647 is larger than the maximum of (2097151|65536) for a GLOBAL_BUFFER_COUNT
 %GDE-I-SEGIS, in BG segment DEFAULT
 
 %GDE-E-OBJNOTCHG, Not changing segment DEFAULT
 %GDE-I-NOACTION, Not updating Global Directory ##TEST_PATH##/mumps.gld
 # TEST CHANGING BUFFERCOUNT VIA MUPIP
-##TEST_AWK%YDB-W-MUPIPSET2BIG, 2147483647 too large, maximum GLOBAL_BUFFERS allowed is [0-9]*
+##TEST_AWK%YDB-W-MUPIPSET2BIG, 2147483647 too large, maximum GLOBAL_BUFFERS allowed is (2097151|65536)
 %YDB-E-WCERRNOTCHG, Not all specified database files were changed
 
 ----------------------------------------------------------------------------------
@@ -60,7 +60,7 @@
 	##TEST_PATH##/mumps.gld
 %GDE-I-VERIFY, Verification OK
 
-##TEST_AWK%GDE-I-VALTOOBIG, 2147483648 is larger than the maximum of [0-9]* for a GLOBAL_BUFFER_COUNT
+##TEST_AWK%GDE-I-VALTOOBIG, 2147483648 is larger than the maximum of (2097151|65536) for a GLOBAL_BUFFER_COUNT
 %GDE-I-SEGIS, in BG segment DEFAULT
 
 %GDE-E-OBJNOTCHG, Not changing segment DEFAULT

--- a/v63002/u_inref/gtm8766.csh
+++ b/v63002/u_inref/gtm8766.csh
@@ -25,13 +25,15 @@ endif
 if ("64" == "$gtm_platform_size") then
 	@ smallvalminus1=2097151
 	@ smallval=2097152
+	set lowerlim="2Mb"
 else
 	@ smallvalminus1=65535
 	@ smallval=65536
+	set lowerlim="64Kb"
 endif
 
-echo "# In the current version, $smallval is the maximum value accepted by both MUPIP and GDE. In previous versions"
-echo "# $smallval was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE"
+echo "# In the current version, $lowerlim is the maximum value accepted by both MUPIP and GDE. In previous versions"
+echo "# $lowerlim was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE"
 foreach val ($smallvalminus1 $smallval 2147483647 2147483648)
 
 	echo ""

--- a/v63002/u_inref/gtm8766.csh
+++ b/v63002/u_inref/gtm8766.csh
@@ -22,9 +22,17 @@ $GDE change -segment DEFAULT -access_method=BG >& accessmethod.out
 if ($status) then
 	echo "# UNABLE TO CHANGE ACCESS METHOD"
 endif
-echo "# In the current version, 2MB is the maximum value accepted by both MUPIP and GDE. In previous versions"
-echo "# 2MB was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE"
-foreach val (2097151 2097152 2147483647 2147483648)
+if ("64" == "$gtm_platform_size") then
+	@ smallvalminus1=2097151
+	@ smallval=2097152
+else
+	@ smallvalminus1=65535
+	@ smallval=65536
+endif
+
+echo "# In the current version, $smallval is the maximum value accepted by both MUPIP and GDE. In previous versions"
+echo "# $smallval was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE"
+foreach val ($smallvalminus1 $smallval 2147483647 2147483648)
 
 	echo ""
 	echo "# CHANGING THE BUFFER COUNT TO $val"

--- a/v63002/u_inref/gtm8766.csh
+++ b/v63002/u_inref/gtm8766.csh
@@ -25,14 +25,14 @@ endif
 if ("64" == "$gtm_platform_size") then
 	@ smallvalminus1=2097151
 	@ smallval=2097152
-	set lowerlim="2Mb"
+	set lowerlim="2Mb-1"
 else
 	@ smallvalminus1=65536
 	@ smallval=65537
 	set lowerlim="64Kb"
 endif
 
-echo "# In the current version, $lowerlim is the maximum value accepted by both MUPIP and GDE. In previous versions"
+echo "# In the current version, $lowerlim (for $gtm_platform_size bit builds) is the maximum value accepted by both MUPIP and GDE. In previous versions"
 echo "# $lowerlim was the max for MUPIP, but a core would be produced for a value greater than or equal to 2GB, and 2GB was the max value for GDE"
 foreach val ($smallvalminus1 $smallval 2147483647 2147483648)
 

--- a/v63002/u_inref/gtm8766.csh
+++ b/v63002/u_inref/gtm8766.csh
@@ -27,8 +27,8 @@ if ("64" == "$gtm_platform_size") then
 	@ smallval=2097152
 	set lowerlim="2Mb"
 else
-	@ smallvalminus1=65535
-	@ smallval=65536
+	@ smallvalminus1=65536
+	@ smallval=65537
 	set lowerlim="64Kb"
 endif
 


### PR DESCRIPTION
We occasionally saw test failures that would fail because on a 32 bit box, the lower limit would be different than on a 64 big box. To circumvent this issue, we take note of what kind of box we are working with and set the lower limit accordingly, and modified the reference file to be more generalized to account for this