### PR TITLE
New r124/ydb312_gtm8182a subtest (tests portion of YDB-312  in V63004)

### DIFF
--- a/r124/inref/ydb312gtm8182a.m
+++ b/r124/inref/ydb312gtm8182a.m
@@ -1,0 +1,42 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+gtm8182a
+	DO getPaths
+
+	WRITE "    Update the INST1 DB",!
+	SET ^today="7/18/2018"
+
+	WRITE "    Read from INST3 DB",!
+	WRITE "        Django: ",^|INST3gbldir|Django,!
+
+	;call jnlprocnum.csh to return the number or processes attached
+	;to our JNL pools
+	ZSYSTEM "$gtm_tst/r124/u_inref/jnlprocnum.csh"
+
+	quit
+
+updateINST3
+	DO getPaths
+	SET $ZGBLDIR=INST3gbldir
+	SET ^Django="Unchained"
+
+	quit
+
+getPaths
+	SET INST1path=$ZTRNLNM("path_INST1","","","","","VALUE")
+	SET INST1gbldir=INST1path_"/mumps.gld"
+
+	SET INST3path=$ZTRNLNM("path_INST3","","","","","VALUE")
+	SET INST3gbldir=INST3path_"/mumps.gld"
+
+	quit

--- a/r124/instream.csh
+++ b/r124/instream.csh
@@ -11,9 +11,9 @@
 #								#
 #################################################################
 #
-#-------------------------------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------------------------------------------------------------
 # List of subtests of the form "subtestname [author] description"
-#-------------------------------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------------------------------------------------------------
 # readonly         [nars]  Test update on database with READ_ONLY flag through multiple global directories
 # ydb275socketpass [nars]  Test that LISTENING sockets can be passed through JOB or WRITE /PASS and WRITE /ACCEPT
 # ydb280socketwait [nars]  Test that WRITE /WAIT on a SOCKET device with no sockets does not spin loop
@@ -21,7 +21,8 @@
 # jnlunxpcterr     [nars]  Test that MUPIP JOURNAL -EXTRACT does not issue JNLUNXPCTERR error in the face of concurrent udpates
 # ydb293	   [vinay] Tests the update process operates correctly with triggers and SET $ZGBLDIR
 # ydb297	   [vinay] Demonstrates LOCK commands work correctly when there are more than 31 subscripts that hash to the same value
-#-------------------------------------------------------------------------------------------------------------
+# ydb312_gtm8182a  [Jake]  Test that when Instance Freeze is disabled a process attaches a region to an instance at the first update to that region.
+#---------------------------------------------------------------------------------------------------------------------------------------------------
 
 echo "r124 test starts..."
 
@@ -30,7 +31,7 @@ setenv subtest_list_common     ""
 setenv subtest_list_non_replic ""
 setenv subtest_list_non_replic "$subtest_list_non_replic readonly ydb275socketpass ydb280socketwait jnlunxpcterr ydb297"
 setenv subtest_list_replic     ""
-setenv subtest_list_replic     "$subtest_list_replic ydb282srcsrvrerr ydb293"
+setenv subtest_list_replic     "$subtest_list_replic ydb282srcsrvrerr ydb293 ydb312_gtm8182a"
 
 setenv subtest_exclude_list    ""
 # filter out white box tests that cannot run in pro

--- a/r124/outref/outref.txt
+++ b/r124/outref/outref.txt
@@ -11,5 +11,6 @@ PASS from ydb297
 PASS from ydb282srcsrvrerr
 ##ALLOW_OUTPUT PRO
 PASS from ydb293
+PASS from ydb312_gtm8182a
 ##ALLOW_OUTPUT NON_REPLIC
 r124 test DONE.

--- a/r124/outref/ydb312_gtm8182a.txt
+++ b/r124/outref/ydb312_gtm8182a.txt
@@ -1,0 +1,28 @@
+# Create the DB
+
+
+# start INST1-INST2 and INST3-INST4 connections
+==Executing MULTISITE_REPLIC 'START INST1 INST2'==
+Starting Primary Source Server in ##TEST_PATH##
+Starting Passive Source Server and Receiver Server in ##FILTERED##_REMOTE_TEST_PATH_/instance2
+==Executing MULTISITE_REPLIC 'START INST3 INST4'==
+Starting Primary Source Server in ##FILTERED##_REMOTE_TEST_PATH_/instance3
+Starting Passive Source Server and Receiver Server in ##FILTERED##_REMOTE_TEST_PATH_/instance4
+
+# run updateINST3^ydb312gtm8182a.m to write variable to INST3 DB to read later
+
+# run ydb312gtm8182a.m to:
+#  	-update INST1
+#  	-read from INST3
+#  	-show attached processes of each INST JNLPOOL
+
+    Update the INST1 DB
+    Read from INST3 DB
+        Django: Unchained
+    number of processes attached to JNLPOOL1: 2
+    number of processes attached to JNLPOOL2: 2
+
+
+# Check and shutdown the DB
+----------------------------------------------------------------------------
+# DB has shutdown gracefully

--- a/r124/u_inref/jnlprocnum.csh
+++ b/r124/u_inref/jnlprocnum.csh
@@ -1,0 +1,30 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+
+# Get Shared Memory ID of the INST1 JNLPOOL
+$ydb_dist/mupip ftok -jnlpool mumps.repl |& $grep mumps.repl | $tst_awk '{print $6}' >& shm1.out
+
+# Get Shared Memory ID of the INST1 JNLPOOL
+cd $path_INST3
+$ydb_dist/mupip ftok -jnlpool mumps.repl |& $grep mumps.repl | $tst_awk '{print $6}' >& $path_INST1/shm2.out
+cd $path_INST1
+
+# Use the JNLPOOL Shared MEMORY IDs to get the # of processes attached ot each JNLPOOL
+echo -n "    number of processes attached to JNLPOOL1: "
+ipcs -a | $grep `cat ./shm1.out` | $tst_awk '{print $NF}'
+
+echo -n "    number of processes attached to JNLPOOL2: "
+ipcs -a | $grep `cat ./shm2.out` | $tst_awk '{print $NF}'
+
+echo ""

--- a/r124/u_inref/ydb312_gtm8182a.csh
+++ b/r124/u_inref/ydb312_gtm8182a.csh
@@ -1,0 +1,64 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# Set white box testing environment to avoid assert failures along with REPLMULTINSTUPDATE error
+setenv gtm_white_box_test_case_enable 1
+setenv gtm_white_box_test_case_number 137
+setenv gtm_repl_instance "mumps.repl"
+
+$MULTISITE_REPLIC_PREPARE 4
+
+echo "# Create the DB"
+# Set up a non replicated region HREG for our trigger activities (the 9th region from the dbcreate)
+# Relies on the existance of HREG, hence the 9 region DB
+setenv gtm_test_repl_norepl 1
+$gtm_tst/com/dbcreate.csh mumps 9 -gld_has_db_fullpath >>& dbcreate.out
+if ($status) then
+	echo "DB Create Failed, Output Below"
+	cat dbcreate.out
+	exit -1
+endif
+echo ""
+echo ""
+
+setenv path_INST1 `$tst_awk '{-F " "; if ($1" "$2 ~ /INST1 DBDIR/)  print $3}' $tst_working_dir/msr_instance_config.txt`
+setenv path_INST3 `$tst_awk '{-F " "; if ($1" "$2 ~ /INST3 DBDIR/)  print $3}' $tst_working_dir/msr_instance_config.txt`
+
+echo "# start INST1-INST2 and INST3-INST4 connections"
+$MSR START INST1 INST2
+$MSR START INST3 INST4
+echo ""
+
+echo "# run updateINST3^ydb312gtm8182a.m to write variable to INST3 DB to read later"
+#$MSR RUN INST3 '$gtm_dist/mumps -run ^%XCMD "set force^=3'
+$gtm_dist/mumps -run updateINST3^ydb312gtm8182a
+echo ""
+
+
+echo "# run ydb312gtm8182a.m to:"
+echo "#  	-update INST1"
+echo "#  	-read from INST3"
+echo "#  	-show attached processes of each INST JNLPOOL"
+echo ""
+$gtm_dist/mumps -run gtm8182a^ydb312gtm8182a
+echo ""
+
+echo "# Check and shutdown the DB"
+echo "----------------------------------------------------------------------------"
+$gtm_tst/com/dbcheck.csh >>& check.out
+if ($status) then
+	echo "DB Check Failed, Output Below"
+	cat check.out
+	exit -1
+endif
+echo "# DB has shutdown gracefully"


### PR DESCRIPTION
This excerpt form the initial GTM-8182 patch notes were not entirely accurate

"When Instance Freeze is enabled (gtm_custom_errors is appropriately defined), a process attaches a region to an instance at the first access to the region; the access may be a read or a VIEW/$VIEW(). Otherwise, the process attaches to a region at the first update to that region. "

Previously, any access at all would attach a process to an instance's JNLPOOL. This subtest tests that changes made in ydb312 now only attach a process to a region when an update is made to the region.