### PR TITLE
Fixed occasional test failures for gtm8644

### DIFF
--- a/v63002/u_inref/gtm8644.csh
+++ b/v63002/u_inref/gtm8644.csh
@@ -16,5 +16,5 @@
 setenv SHELL /usr/local/bin/tcsh
 $ydb_dist/mumps -run shellfn^gtm8644
 $ydb_dist/mumps -run psforestfn^gtm8644 >& processtree.out
-cat processtree.out |& $grep -A 2 "gtm8644.csh" |& $tst_awk '{print $8,$9,$10,$11,$12,$13}'
+cat processtree.out |& $grep -A 2 "gtm8644.csh" |& sed 's/\<|\>//g' |& $tst_awk '{print $8,$9,$10,$11,$12,$13}'
 $ydb_dist/mumps -run quotesfn^gtm8644


### PR DESCRIPTION
We had a test failure which came from an extra branch being created in the process tree during the weekend testing. To circumvent this, we added a sed to remove the extra character before the test awk