### PR TITLE
New r124/ydb315 subtest (tests YottaDB/YottaDB#315 in r1.24)

### DIFF
--- a/r124/inref/blktoodeep.m
+++ b/r124/inref/blktoodeep.m
@@ -1,0 +1,18 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+blktoodeep
+
+        . WRITE !," o  Directory does not exist: "_XOBDIR
+
+        quit
+

--- a/r124/inref/ydb315.m
+++ b/r124/inref/ydb315.m
@@ -11,21 +11,23 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
 ydb315
-	WRITE "nosetZcomp"
-	DO nosetZcomp
-	WRITE !
 
-	WRITE "setZcomp"
-	DO setZcomp
-	WRITE !
-
-	quit
-
-setZcomp
-	SET $ZCOMPILE=$ZCOMPILE_" -nowarning"
-	ZCOMPILE "$gtm_tst/r124/inref/blktoodeep.m"
 	quit
 
 nosetZcomp
 	ZCOMPILE "$gtm_tst/r124/inref/blktoodeep.m"
+
         quit
+
+setZcompNoWarning
+	SET $ZCOMPILE=$ZCOMPILE_" -nowarning"
+	ZCOMPILE "$gtm_tst/r124/inref/blktoodeep.m"
+
+	quit
+
+
+setZcompWarning
+	SET $ZCOMPILE=$ZCOMPILE_" -warning"
+	ZCOMPILE "$gtm_tst/r124/inref/blktoodeep.m"
+
+	quit

--- a/r124/inref/ydb315.m
+++ b/r124/inref/ydb315.m
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
+;	This source code contains the intellectual property	;
+;	of its copyright holder(s), and is made available	;
+;	under a license.  If you do not know the terms of	;
+;	the license, please stop and do not read further.	;
+;								;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+ydb315
+	WRITE "nosetZcomp"
+	DO nosetZcomp
+	WRITE !
+
+	WRITE "setZcomp"
+	DO setZcomp
+	WRITE !
+
+	quit
+
+setZcomp
+	SET $ZCOMPILE=$ZCOMPILE_" -nowarning"
+	ZCOMPILE "$gtm_tst/r124/inref/blktoodeep.m"
+	quit
+
+nosetZcomp
+	ZCOMPILE "$gtm_tst/r124/inref/blktoodeep.m"
+        quit

--- a/r124/instream.csh
+++ b/r124/instream.csh
@@ -21,6 +21,7 @@
 # jnlunxpcterr     [nars]  Test that MUPIP JOURNAL -EXTRACT does not issue JNLUNXPCTERR error in the face of concurrent udpates
 # ydb293	   [vinay] Tests the update process operates correctly with triggers and SET $ZGBLDIR
 # ydb297	   [vinay] Demonstrates LOCK commands work correctly when there are more than 31 subscripts that hash to the same value
+# ydb315	   [jake]  Tests that the ZCOMPILE operation will not dispaly warning if $ZCOMPILE contains "-nowarnings"
 #-------------------------------------------------------------------------------------------------------------
 
 echo "r124 test starts..."
@@ -28,7 +29,7 @@ echo "r124 test starts..."
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
 setenv subtest_list_non_replic ""
-setenv subtest_list_non_replic "$subtest_list_non_replic readonly ydb275socketpass ydb280socketwait jnlunxpcterr ydb297"
+setenv subtest_list_non_replic "$subtest_list_non_replic readonly ydb275socketpass ydb280socketwait jnlunxpcterr ydb297 ydb315"
 setenv subtest_list_replic     ""
 setenv subtest_list_replic     "$subtest_list_replic ydb282srcsrvrerr ydb293"
 

--- a/r124/instream.csh
+++ b/r124/instream.csh
@@ -21,7 +21,7 @@
 # jnlunxpcterr     [nars]  Test that MUPIP JOURNAL -EXTRACT does not issue JNLUNXPCTERR error in the face of concurrent udpates
 # ydb293	   [vinay] Tests the update process operates correctly with triggers and SET $ZGBLDIR
 # ydb297	   [vinay] Demonstrates LOCK commands work correctly when there are more than 31 subscripts that hash to the same value
-# ydb315	   [jake]  Tests that the ZCOMPILE operation will not dispaly warning if $ZCOMPILE contains "-nowarnings"
+# ydb315	   [jake]  Tests that the ZCOMPILE operation will not display warning if $ZCOMPILE contains "-nowarnings"
 #-------------------------------------------------------------------------------------------------------------
 
 echo "r124 test starts..."

--- a/r124/outref/outref.txt
+++ b/r124/outref/outref.txt
@@ -5,6 +5,7 @@ PASS from ydb275socketpass
 PASS from ydb280socketwait
 PASS from jnlunxpcterr
 PASS from ydb297
+PASS from ydb315
 ##ALLOW_OUTPUT REPLIC
 ##SUSPEND_OUTPUT NON_REPLIC
 ##SUSPEND_OUTPUT PRO

--- a/r124/outref/ydb315.txt
+++ b/r124/outref/ydb315.txt
@@ -1,0 +1,28 @@
+# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with no '-nowarning' flag (expecting warnings)
+	        . WRITE !," o  Directory does not exist: "_XOBDIR
+	          ^-----
+		At column 11, line 15, source module ##IN_TEST_PATH##/inref/blktoodeep.m
+%YDB-W-BLKTOODEEP, Block level too deep
+
+# Run setZcompNoWarning^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set directly (expecting no warnings)
+
+# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in $ydb_compile (expecting no warnings)
+
+# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in $gtmcompile (expecting no warnings)
+
+# Run setZcompNoWarning^ydb315.m to attempt to compile blktoodeep.m with the '-warning' flag set in $gtmcompile  and the '-nowarning' flag set directly (expecting no warnings)
+
+# Run setZcompNoWarning^ydb315.m to attempt to compile blktoodeep.m with the '-warning' flag set in $ydb_compile  and the '-nowarning' flag set directly (expecting no warnings)
+
+# Run setZcompWarning^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in $gtmcompile  and the '-warning' flag set directly (expecting warnings)
+	        . WRITE !," o  Directory does not exist: "_XOBDIR
+	          ^-----
+		At column 11, line 15, source module ##IN_TEST_PATH##/inref/blktoodeep.m
+%YDB-W-BLKTOODEEP, Block level too deep
+
+# Run setZcompWarning^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in $ydb_compile  and the '-warning' flag set directly (expecting warnings)
+	        . WRITE !," o  Directory does not exist: "_XOBDIR
+	          ^-----
+		At column 11, line 15, source module ##IN_TEST_PATH##/inref/blktoodeep.m
+%YDB-W-BLKTOODEEP, Block level too deep
+

--- a/r124/u_inref/ydb315.csh
+++ b/r124/u_inref/ydb315.csh
@@ -1,0 +1,33 @@
+#!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+echo "# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with no '-nowarning' flag (expecting warnings)"
+$ydb_dist/mumps -run nosetZcomp^ydb315
+echo ""
+
+echo "# Run setZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set directly (expecting no warnings)"
+$ydb_dist/mumps -run setZcomp^ydb315
+echo ""
+
+setenv ydb_compile "-nowarning"
+unsetenv ydb_compile
+echo "# Run noZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"ydb_compile (expecting no warnings)"
+$ydb_dist/mumps -run setZcomp^ydb315
+echo ""
+
+setenv gtmcompile "-nowarning"
+echo "# Run noZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"gtmcompile (expecting no warnings)"
+$ydb_dist/mumps -run setZcomp^ydb315
+echo ""
+
+unsetenv gtmcompile

--- a/r124/u_inref/ydb315.csh
+++ b/r124/u_inref/ydb315.csh
@@ -15,19 +15,48 @@ echo "# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with no '-now
 $ydb_dist/mumps -run nosetZcomp^ydb315
 echo ""
 
-echo "# Run setZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set directly (expecting no warnings)"
-$ydb_dist/mumps -run setZcomp^ydb315
+echo "# Run setZcompNoWarning^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set directly (expecting no warnings)"
+$ydb_dist/mumps -run setZcompNoWarning^ydb315
 echo ""
 
 setenv ydb_compile "-nowarning"
-unsetenv ydb_compile
-echo "# Run noZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"ydb_compile (expecting no warnings)"
-$ydb_dist/mumps -run setZcomp^ydb315
+echo "# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"ydb_compile (expecting no warnings)"
+$ydb_dist/mumps -run nosetZcomp^ydb315
 echo ""
 
+unsetenv ydb_compile
+
 setenv gtmcompile "-nowarning"
-echo "# Run noZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"gtmcompile (expecting no warnings)"
-$ydb_dist/mumps -run setZcomp^ydb315
+echo "# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"gtmcompile (expecting no warnings)"
+$ydb_dist/mumps -run nosetZcomp^ydb315
 echo ""
 
 unsetenv gtmcompile
+
+setenv gtmcompile "-warning"
+echo "# Run setZcompNoWarning^ydb315.m to attempt to compile blktoodeep.m with the '-warning' flag set in "'$'"gtmcompile  and the '-nowarning' flag set directly (expecting no warnings)"
+$ydb_dist/mumps -run setZcompNoWarning^ydb315
+echo ""
+
+unsetenv gtmcompile
+
+setenv ydb_compile "-warning"
+echo "# Run setZcompNoWarning^ydb315.m to attempt to compile blktoodeep.m with the '-warning' flag set in "'$'"ydb_compile  and the '-nowarning' flag set directly (expecting no warnings)"
+$ydb_dist/mumps -run setZcompNoWarning^ydb315
+echo ""
+
+unsetenv ydb_compile
+
+setenv gtmcompile "-nowarning"
+echo "# Run setZcompWarning^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"gtmcompile  and the '-warning' flag set directly (expecting warnings)"
+$ydb_dist/mumps -run setZcompWarning^ydb315
+echo ""
+
+unsetenv gtmcompile
+
+setenv ydb_compile "-nowarning"
+echo "# Run setZcompWarning^ydb315.m to attempt to compile blktoodeep.m with the '-nowarning' flag set in "'$'"ydb_compile  and the '-warning' flag set directly (expecting warnings)"
+$ydb_dist/mumps -run setZcompWarning^ydb315
+echo ""
+
+unsetenv ydb_compile

--- a/r124/u_inref/ydb315.csh
+++ b/r124/u_inref/ydb315.csh
@@ -11,6 +11,10 @@
 #								#
 #################################################################
 #
+#The compile env vars are unset to avoid complications from parent environment
+unsetenv ydb_compile
+unsetenv gtmcompile
+
 echo "# Run nosetZcomp^ydb315.m to attempt to compile blktoodeep.m with no '-nowarning' flag (expecting warnings)"
 $ydb_dist/mumps -run nosetZcomp^ydb315
 echo ""


### PR DESCRIPTION
Tests the following release note

ZCOMPILE does not issue warnings during compilation if $ZCOMPILE has "-nowarning" in it. Previously, the compilation incorrectly issued warnings in this setting. Note that one can set $ZCOMPILE directly or through the environment variable ydb_compile/gtmcompile.