### PR TITLE
Fixed occasional test failures for gtm8694

### DIFF
--- a/v63002/outref/gtm8694.txt
+++ b/v63002/outref/gtm8694.txt
@@ -94,7 +94,7 @@ Region	DEFAULT
 DSE> 
 # TESTING CENABLE
 YDB>#<CTRL-C>
-YDB>%YDB-I-CTRLC, CTRL_C encountered
+##TEST_AWK.*YDB-I-CTRLC, CTRL_C encountered
 
 # -------------------------------------------------------------------------
 
@@ -138,7 +138,7 @@ Region	DEFAULT
 DSE> 
 # TESTING CENABLE
 YDB>#<CTRL-C>
-YDB>%YDB-I-CTRLC, CTRL_C encountered
+##TEST_AWK.*YDB-I-CTRLC, CTRL_C encountered
 
 # -----------------------------------------------------------------------
 


### PR DESCRIPTION
Previously, the test would fail due to timing issues with the expect script. We added a test_awk to the reference file to generalize it to account for this