### PR TITLE
Fix occasional gtcm_omi/basic test failure in case backward processing restarts

### DIFF
--- a/gtcm_omi/outref/basic.txt
+++ b/gtcm_omi/outref/basic.txt
@@ -12,21 +12,18 @@ mumps.dat
 %YDB-I-JNLCREATE, Journal file ##TEST_PATH##/b.mjl created for database file ##TEST_PATH##/b.dat with NOBEFORE_IMAGES
 %YDB-I-JNLSTATE, Journaling state for database file ##TEST_PATH##/b.dat is now ON
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file extd1.out created
 %YDB-S-JNLSUCCESS, Extract successful
 %YDB-S-JNLSUCCESS, Verify successful
 ##FILTERED##%YDB-I-MUJNLSTAT, End processing at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file exta1.out created
 %YDB-S-JNLSUCCESS, Extract successful
 %YDB-S-JNLSUCCESS, Verify successful
 ##FILTERED##%YDB-I-MUJNLSTAT, End processing at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file extb1.out created
 %YDB-S-JNLSUCCESS, Extract successful
@@ -43,21 +40,18 @@ YDB>
 h
 %YDB-I-JNLSTATE, Journaling state for database file ##TEST_PATH##/mumps.dat is now OFF
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file extd2.out created
 %YDB-S-JNLSUCCESS, Extract successful
 %YDB-S-JNLSUCCESS, Verify successful
 ##FILTERED##%YDB-I-MUJNLSTAT, End processing at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file exta2.out created
 %YDB-S-JNLSUCCESS, Extract successful
 %YDB-S-JNLSUCCESS, Verify successful
 ##FILTERED##%YDB-I-MUJNLSTAT, End processing at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file extb2.out created
 %YDB-S-JNLSUCCESS, Extract successful
@@ -81,21 +75,18 @@ YDB>
 YDB>
 h
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file extd3.out created
 %YDB-S-JNLSUCCESS, Extract successful
 %YDB-S-JNLSUCCESS, Verify successful
 ##FILTERED##%YDB-I-MUJNLSTAT, End processing at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file exta3.out created
 %YDB-S-JNLSUCCESS, Extract successful
 %YDB-S-JNLSUCCESS, Verify successful
 ##FILTERED##%YDB-I-MUJNLSTAT, End processing at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
-##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file extb3.out created
 %YDB-S-JNLSUCCESS, Extract successful

--- a/gtcm_omi/u_inref/tstswjnl.csh
+++ b/gtcm_omi/u_inref/tstswjnl.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2002-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -19,9 +22,11 @@ $gtm_exe/mupip set -file -journal=on,nobe,enable mumps.dat
 $gtm_exe/mupip set -file -journal=on,nobe,enable a.dat
 $gtm_exe/mupip set -file -journal=on,nobe,enable b.dat
 
-$gtm_exe/mupip journal -extract=extd1.out -forward mumps.mjl
-$gtm_exe/mupip journal -extract=exta1.out -forward a.mjl
-$gtm_exe/mupip journal -extract=extb1.out -forward b.mjl
+alias jnlext '$gtm_exe/mupip journal -extract=\!:1 -forward \!:2 |& $grep -v "Backward processing"'
+
+jnlext extd1.out mumps.mjl
+jnlext exta1.out a.mjl
+jnlext extb1.out b.mjl
 
 $GTM << endt
 w !,"Starting tests via viagtcm^tstswjnl",! do viagtcm^tstswjnl
@@ -31,9 +36,9 @@ endt
 #Since we are doing connections across OMI the regions will be open the issue is similar to switching journal files on the fly.
 
 $gtm_exe/mupip set -file -journal=off mumps.dat
-$gtm_exe/mupip journal -extract=extd2.out -forward mumps.mjl
-$gtm_exe/mupip journal -extract=exta2.out -forward a.mjl
-$gtm_exe/mupip journal -extract=extb2.out -forward b.mjl
+jnlext extd2.out mumps.mjl
+jnlext exta2.out a.mjl
+jnlext extb2.out b.mjl
 $gtm_exe/mupip set -file -journal=on,nobe mumps.dat
 
 $GTM << wxyz
@@ -46,9 +51,9 @@ $GTM << wxyz
 w "h",! h
 wxyz
 
-$gtm_exe/mupip journal -extract=extd3.out -forward mumps.mjl
-$gtm_exe/mupip journal -extract=exta3.out -forward a.mjl
-$gtm_exe/mupip journal -extract=extb3.out -forward b.mjl
+jnlext extd3.out mumps.mjl
+jnlext exta3.out a.mjl
+jnlext extb3.out b.mjl
 
 $gtm_tst/$tst/u_inref/gtcm_stop.csh >& gtcm_stop.log
 $gtm_tst/com/dbcheck.csh


### PR DESCRIPTION
This test used to fail occasionally before with a JNLUNXPCTERR error because the journal file changed
(due to concurrent updates) while the MUPIP JOURNAL -EXTRACT was running. That was fixed as part of
https://github.com/YottaDB/YottaDB/issues/284. After that, in case a file state change is recognized
by the MUPIP JOURNAL -EXTRACT, it restarts backward processing. But if it does that, it prints 2 extra
lines (the line containing "Restarting Backward processing" and the immediately following line which
says "Backward processing started"). Below is a sample output from an actual test failure.
```
 ##FILTERED##%YDB-I-MUJNLSTAT, Initial processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-MUJNLSTAT, Restarting Backward processing at Sat Jul 21 09:52:16 2018
 ##FILTERED##%YDB-I-MUJNLSTAT, Backward processing started at ... ... .. ..:..:.. 20..
 ##FILTERED##%YDB-I-MUJNLSTAT, Forward processing started at ... ... .. ..:..:.. 20..
 %YDB-I-FILECREATE, Journal extract file exta2.out created 
 %YDB-S-JNLSUCCESS, Extract successful
 %YDB-S-JNLSUCCESS, Verify successful
 ##FILTERED##%YDB-I-MUJNLSTAT, End processing at ... ... .. ..:..:.. 20..
```
And since the output is part of the reference file, the test fails.
The test does a lot of journal extracts and I suspect any of them could have this extra-2-lines issue.
So this test is fixed by filtering out all lines containing "Backward processing" in them that way the
output is stable whether or not the backward processing gets restarted. The only side effect of that is
that the line containing "Backward processing" which occurs after the line saying "Initial processing"
would also get filtered out. But that is considered okay since the important thing is the JNLSUCCESS at the end.