### PR TITLE
Disable r124/ydb297 subtest on 32-bit Linux ARM, it is still enabled on x86_64

### DIFF
--- a/r124/instream.csh
+++ b/r124/instream.csh
@@ -33,16 +33,22 @@ setenv subtest_list_non_replic "$subtest_list_non_replic readonly ydb275socketpa
 setenv subtest_list_replic     ""
 setenv subtest_list_replic     "$subtest_list_replic ydb282srcsrvrerr ydb293"
 
+if ($?test_replic == 1) then
+	setenv subtest_list "$subtest_list_common $subtest_list_replic"
+else
+	setenv subtest_list "$subtest_list_common $subtest_list_non_replic"
+endif
+
 setenv subtest_exclude_list    ""
+
 # filter out white box tests that cannot run in pro
 if ("pro" == "$tst_image") then
 	setenv subtest_exclude_list "$subtest_exclude_list ydb282srcsrvrerr"
 endif
 
-if ($?test_replic == 1) then
-	setenv subtest_list "$subtest_list_common $subtest_list_replic"
-else
-	setenv subtest_list "$subtest_list_common $subtest_list_non_replic"
+if ("HOST_LINUX_ARMVXL" == $gtm_test_os_machtype) then
+	# filter out below test on 32-bit ARM since it relies on hash collisions which happen only on Linux x86_64 currently
+	setenv subtest_exclude_list "$subtest_exclude_list ydb297"
 endif
 
 # Submit the list of subtests

--- a/r124/outref/outref.txt
+++ b/r124/outref/outref.txt
@@ -4,7 +4,9 @@ PASS from readonly
 PASS from ydb275socketpass
 PASS from ydb280socketwait
 PASS from jnlunxpcterr
+##SUSPEND_OUTPUT HOST_LINUX_ARMVXL
 PASS from ydb297
+##ALLOW_OUTPUT HOST_LINUX_ARMVXL
 PASS from ydb315
 ##ALLOW_OUTPUT REPLIC
 ##SUSPEND_OUTPUT NON_REPLIC


### PR DESCRIPTION
The test carefully chooses subscripts that hash to the same bucket. It expects and sees 41 collisions
on x86_64 but on the 32-bit ARM build, it sees none. This is because the hash algorithm generates
different value on 32-bit vs 64-bit builds. I am not sure exactly where the difference lies but I don't
think that is worth pursuing since we are testing the hash collision stuff at least on x86_64.