### PR TITLE
Fix v63002/gtm8644 subtest failure (really remove extra pipe symbol in ps --forest output)

### DIFF
--- a/v63002/u_inref/gtm8644.csh
+++ b/v63002/u_inref/gtm8644.csh
@@ -16,5 +16,5 @@
 setenv SHELL /usr/local/bin/tcsh
 $ydb_dist/mumps -run shellfn^gtm8644
 $ydb_dist/mumps -run psforestfn^gtm8644 >& processtree.out
-cat processtree.out |& $grep -A 2 "gtm8644.csh" |& sed 's/\<|\>//g' |& $tst_awk '{print $8,$9,$10,$11,$12,$13}'
+cat processtree.out |& $grep -A 2 "gtm8644.csh" |& sed 's/ | //g' |& $tst_awk '{print $8,$9,$10,$11,$12,$13}'
 $ydb_dist/mumps -run quotesfn^gtm8644


### PR DESCRIPTION
The prior commit to gtm8644.csh did attempted to fix this issue but it had a sed expression of
\\<|\\> implying a match of a | symbol that is a full word. For reasons unknown that does not work
so this is now replaced with a " | " (pipe surrounded by spaces) which works and achieves the
same objective.