### PR TITLE
Fix occasional v63003/gtm8805 subtest hang if test framework randomly chooses spanning regions

### DIFF
--- a/v63003/inref/gtm8805.m
+++ b/v63003/inref/gtm8805.m
@@ -19,13 +19,13 @@ gtm8805
 
 child
 
-	for  quit:^a(jobindex)
+	for  quit:^a(jobindex)  hang 0.1
 	; Lock ^x, await a signal to trigger an ungraceful shutdown
 	if jobindex=1 do
 	. lock +^x
 	. set:($test) ^B($increment(^b))="# Process 1: Currently holds ^x"
 	. set ^a(2)=1
-	. for  quit:^a(4)
+	. for  quit:^a(4)  hang 0.1
 	. set ^B($increment(^b))="# Process 1: Issuing a kill -9"
 	. zsystem "kill -9 "_$j
 
@@ -37,7 +37,7 @@ child
 	. use p
 	. write "find -region=DEFAULT",!
 	. write "crit -seize",!
-	. for  read x($incr(x))  quit:(x(x)["Seized")  hang 1
+	. for  read x($incr(x))  quit:(x(x)["Seized")  hang 0.1
 	. set ^B($increment(^b))="# Process 2: "_x(x)
 	. set ^a(3)=1
 
@@ -51,6 +51,6 @@ child
 	. set ^B($increment(^b))="# Process 3: Lock successfully acquired by Process 3 after ungraceful shutdown of process 1"
 	. set ^a(5)=1
 
-	for  quit:^a(5)
+	for  quit:^a(5)  hang 0.1
 
 	quit

--- a/v63003/u_inref/gtm8805.csh
+++ b/v63003/u_inref/gtm8805.csh
@@ -14,7 +14,9 @@
 #
 #
 
-# Default used for DSE crit seize, AREG used to dictate order of execution, BREG used as an eventlog
+setenv gtm_test_spanreg 0	# Disable spanning regions as this test relies on ^a updates going to AREG, ^b updates going to BREG
+				# and none of these going to DEFAULT since that region would have crit seized by DSE
+# DEFAULT region used for DSE crit seize, AREG used to dictate order of execution, BREG used as an eventlog
 $gtm_tst/com/dbcreate.csh mumps 3>>&dbcreate.out
 if ($status) then
 	cat dbcreate.out


### PR DESCRIPTION
If the test framework randomly chooses spanning regions (i.e. gtm_test_spanreg env var is set to 1)
and if a pre-computed gde mapping file is available for the random choice of chset and collation
that would be used by dbcreate. This means it is possible ^a(1) gets mapped to AREG while ^a(2)
gets mapped to BREG while ^a(3) gets mapped to DEFAULT. This would cause issues with this test
since it uses DSE to get the crit lock on DEFAULT and so any updates going to DEFAULT will never
happen which means the test would never progress beyond a particular stage and hang eternally.
This is fixed by disabling spanning regions for this test.

Additionally, it was noticed that while the test was hung, mumps processes were spinning. This is
fixed too by changing all for loops to hang a little bit (i.e. sleep-loop instead of spin-loop).