### PR TITLE
Fix weird v63002/gtm8165 hang on armv6l (pi zero)

### DIFF
--- a/v63002/inref/gtm8165.m
+++ b/v63002/inref/gtm8165.m
@@ -68,7 +68,7 @@ writeslashwait
 	. write:($ZTRNLNM("timeout")) /wait(.999)
 	. write:('$ZTRNLNM("timeout")) /wait
 	. close sock
-	if $trestart<=2  do ;cannot use else because this commit changes the value of $test, similar usages throughout the test
+	if $trestart<=2  do  ;cannot use else because this commit changes the value of $test, similar usages throughout the test
 	. set ^Y=$increment(^i)
 	. zsystem "$ydb_dist/mumps -run ^%XCMD 'set ^Y=$increment(^i)'"
 	tcommit
@@ -113,7 +113,7 @@ passchild
 	open sock:(CONNECT="passsocket2:LOCAL")::"SOCKET"
 	use sock
 	use $p
-	for  hang .1  quit:^stop
+	for  quit:^stop  hang .1
 	quit
 
 writeslashaccept
@@ -151,7 +151,7 @@ acceptchild
 	open sock:(CONNECT="acceptsocket:LOCAL")::"SOCKET"
 	use sock
 	use $p
-	for  hang .1  quit:^stop
+	for  quit:^stop  hang .1
 	quit
 
 
@@ -189,5 +189,5 @@ tlschild
 	set sock="socket"
 	open sock:(CONNECT="localhost:3000:TCP":attach="handle")::"SOCKET"
 	use sock
-	for  quit:^stop
+	for  quit:^stop  hang 0.1
 	quit

--- a/v63002/u_inref/gtm8165.csh
+++ b/v63002/u_inref/gtm8165.csh
@@ -21,11 +21,11 @@ foreach arg("writeslashwait" "writeslashpass" "writeslashaccept" "writeslashtls"
 	echo "# Testing command timeout ($arg) greater than .123 (Expect a TPNOTACID message in the syslog)"
 	set t = `date +"%b %e %H:%M:%S"`
 	$ydb_dist/mumps -run $arg^gtm8165
-	$gtm_tst/com/getoper.csh "$t" "" getoper.txt
+	$gtm_tst/com/getoper.csh "$t" "" getoper1_$arg.txt
 	# Sleep included to avoid 1 iteration reading the message from a previous one
 	sleep 1
 	echo "# Checking the syslog"
-	$grep TPNOTACID getoper.txt |& sed 's/.*%YDB-I-TPNOTACID/%YDB-I-TPNOTACID/' |& sed 's/$TRESTART.*//' |& $grep gtm8165
+	$grep TPNOTACID getoper1_$arg.txt |& sed 's/.*%YDB-I-TPNOTACID/%YDB-I-TPNOTACID/' |& sed 's/$TRESTART.*//' |& $grep gtm8165
 	echo ""
 	echo "---------------------------------------------------------------------------------"
 	echo ""
@@ -34,9 +34,9 @@ setenv timeout 0
 foreach arg("writeslashwait" "writeslashpass" "writeslashaccept" "writeslashtls" "locktimeout" "opentimeout")
 	echo "# Testing command without a specified timeout ($arg), Expect a TPNOTACID message in the syslog still"
 	set t = `date +"%b %e %H:%M:%S"`
-	(($ydb_dist/mumps -run $arg^gtm8165>>&tpnotacid.out)&;echo $!>&pid.out)>& bckg.out
+	(($ydb_dist/mumps -run $arg^gtm8165 >& tpnotacid_$arg.out)&;echo $!>&pid.out)>& bckg.out
 	set pid=`cat pid.out`
-	$gtm_tst/com/getoper.csh "$t" "" getoper.txt "" "TPNOTACID"
+	$gtm_tst/com/getoper.csh "$t" "" getoper2_$arg.txt "" "TPNOTACID"
 	kill -9 $pid
 	if ( "writeslashwait" != $arg && "opentimeout" != $arg) then
 		set pid2=`cat $arg.txt`
@@ -44,7 +44,7 @@ foreach arg("writeslashwait" "writeslashpass" "writeslashaccept" "writeslashtls"
 	endif
 	# Sleep included to avoid 1 iteration reading the message from a previous one
 	sleep 1
-	$grep TPNOTACID getoper.txt |& sed 's/.*%YDB-I-TPNOTACID/%YDB-I-TPNOTACID/' |& sed 's/$TRESTART.*//' |& $grep gtm8165
+	$grep TPNOTACID getoper2_$arg.txt |& sed 's/.*%YDB-I-TPNOTACID/%YDB-I-TPNOTACID/' |& sed 's/$TRESTART.*//' |& $grep gtm8165
 	echo ""
 	echo "---------------------------------------------------------------------------------"
 	echo ""


### PR DESCRIPTION
A particular run of the v63002/gtm8165 hung on an armv6l box in internal testing.
The mumps process in the test was hung in line 170 below.
```
v63002/inref/gtm8165.m
----------------------
    158 writeslashtls
      .
    170         . if $ZTRNLNM("timeout")  write /tls("client",.999)
```
But when I ran gdb on the hung process, I got a weird C stack trace.
```
(gdb) where
 #0  0xb6e150c8 in read () at ../sysdeps/unix/syscall-template.S:84
 #1  0xb4f30834 in ?? () from /usr/lib/arm-linux-gnueabihf/libcrypto.so.1.1
```
There was no iosocket_iocontrol() in the C-stack like one would expect if a WRITE /TLS command was running.

This is the client side in the socket connection. At the same time, the server side of the socket connection
 was busy waiting for the client to reach a specific stage.
```
v63002/inref/gtm8165.m
----------------------
    183 tlschild
      .
    192         for  quit:^stop
```
Note that line 192 is a spin-loop. Once I changed the spin loop to be a sleep loop, the issue disappears.
In that, the failure happens reliably with replay with a spin loop and does not happen even once with a sleep loop.

I am not sure why the solution fixes the hang but I suspect that when the client does the WRITE /TLS command,
it waits for some acknowledgement from the server side of the socket but because the server side is caught up
in a spin loop (and the armv6l/pi-zero is a 1-cpu system), it does not ever get to acknowledging the client's
request in a timely fashion resulting in the client side tls code exercising some buggy codepath in the
openssl/tls libraries installed on the Raspbian system.

While at this, I also cleaned up the test a bit so log files are different for different stages of the
test (instead of overwriting the same log file for all stages).