### PR TITLE
Fix v63002/gtm8165 test failure due to hardcoded portno 3000 already in use

### DIFF
--- a/v63002/inref/gtm8165.m
+++ b/v63002/inref/gtm8165.m
@@ -158,7 +158,7 @@ acceptchild
 writeslashtls
 	set ^stop=0
 	set sock="gtm8165.socket"
-	open sock:(LISTEN="3000:TCP":attach="handle")::"SOCKET"
+	open sock:(LISTEN=$ztrnlnm("portno")_":TCP":attach="handle")::"SOCKET"
 	use sock
 	job tlschild
 	write /wait
@@ -187,7 +187,7 @@ tlschild
 	write $job
 	close pid2
 	set sock="socket"
-	open sock:(CONNECT="localhost:3000:TCP":attach="handle")::"SOCKET"
+	open sock:(CONNECT="localhost:"_$ztrnlnm("portno")_":TCP":attach="handle")::"SOCKET"
 	use sock
 	for  quit:^stop  hang 0.1
 	quit

--- a/v63002/u_inref/gtm8165.csh
+++ b/v63002/u_inref/gtm8165.csh
@@ -14,6 +14,8 @@
 #
 #
 $gtm_tst/com/dbcreate.csh mumps 1 >>& dbcreate.out
+# writeslashtls^gtm8165 requires a port number to communicate. So allocate one from the test system framework.
+source $gtm_tst/com/portno_acquire.csh >>& portno.out	# portno env var will be set to the alloted portno
 echo "# Setting gtm_tpnotacidtime to .123 seconds"
 setenv gtm_tpnotacidtime .123
 setenv timeout 1
@@ -50,4 +52,5 @@ foreach arg("writeslashwait" "writeslashpass" "writeslashaccept" "writeslashtls"
 	echo ""
 end
 
+$gtm_tst/com/portno_release.csh	# Release the portno allocated above by portno_acquire.csh
 $gtm_tst/com/dbcheck.csh >>& dbcheck.out


### PR DESCRIPTION
Use portno_acquire.csh and portno_release.csh to acquire a dynamic port number and use that instead of 3000.
We had a Beaglebone Black box where port 3000 was being used as a listening port by a system service and
that caused this test to fail since this tries to use 3000 for a listening socket and that failed with
an EADDRINUSE (Address already in use) error.