### PR TITLE
Fix rare hang in r124/ydb282srcsrvrerr subtest due to database flush timer pop at JNLEXTEND error time

### DIFF
--- a/r124/outref/ydb282srcsrvrerr.txt
+++ b/r124/outref/ydb282srcsrvrerr.txt
@@ -5,6 +5,8 @@
 # Set access method to BG since with MM -jnl_prefix= does not work in dbcreate.csh
 # Set autoswitch to the lowest setting to maximize switching
 ==Executing MULTISITE_REPLIC 'RUN INST2 mkdir -p jnldir'==
+# Create single region database with jnl auto switch limit of 8Mb
+# Set huge flush timer in db file header to avoid a potential hang when running lots of updates below
 # Start only source server (not receiver server) so no connection happens
 # This will ensure journal files are not opened now by source server but later after directory permissions have been changed
 ==Executing MULTISITE_REPLIC 'STARTSRC INST1 INST2 RP'==
@@ -12,10 +14,16 @@
 drwxrwxr-x jnldir
 # Run lots of updates with white-box case enabled (202) to ensure a FILEDELFAIL codepath is later exercised in source server
 # This will also turn write permissions OFF in [jnldir] directory and result in JNLEXTEND/JNLNOCREATE errors
+# And will freeze the instance
 %YDB-E-JNLEXTEND, Journal file extension error for file ##TEST_PATH##/jnldir/mumps.mjl
 %YDB-E-JNLNOCREATE, Journal file  not created
-# Permissions of [jnldir] after change
+# Verify [jnldir] permissions changed during updates
 dr-xr-xr-x jnldir
+# Verify instance did freeze during updates by running a checkhealth
+##FILTERED##... ... .. ..:..:.. 20.. : Initiating CHECKHEALTH operation on source server pid [##PID##] for secondary instance name [INSTANCE2]
+PID ##FILTERED##[##PID##] Source server is alive in ACTIVE mode
+Warning: Instance Freeze is ON
+##TEST_AWK   Freeze Comment: PID [0-9]* encountered JNLEXTEND; Instance frozen
 # Start receiver server so source server connects and opens journal file and exercise FILEDELFAIL codepath
 ==Executing MULTISITE_REPLIC 'STARTRCV INST1 INST2'==
 # Ensure source and receiver are in sync
@@ -32,6 +40,8 @@ dr-xr-xr-x jnldir
 # Set access method to BG since with MM -jnl_prefix= does not work in dbcreate.csh
 # Set autoswitch to the lowest setting to maximize switching
 ==Executing MULTISITE_REPLIC 'RUN INST2 mkdir -p jnldir'==
+# Create single region database with jnl auto switch limit of 8Mb
+# Set huge flush timer in db file header to avoid a potential hang when running lots of updates below
 # Start only source server (not receiver server) so no connection happens
 # This will ensure journal files are not opened now by source server but later after directory permissions have been changed
 ==Executing MULTISITE_REPLIC 'STARTSRC INST1 INST2 RP'==
@@ -39,10 +49,16 @@ dr-xr-xr-x jnldir
 drwxrwxrwx jnldir
 # Run lots of updates with white-box case enabled (202) to ensure a RENAMEFAIL codepath is later exercised in source server
 # This will also turn write permissions OFF in [jnldir] directory and result in JNLEXTEND/JNLNOCREATE errors
+# And will freeze the instance
 %YDB-E-JNLEXTEND, Journal file extension error for file ##TEST_PATH##/jnldir/mumps.mjl
 %YDB-E-JNLNOCREATE, Journal file  not created
-# Permissions of [jnldir] after change
+# Verify [jnldir] permissions changed during updates
 dr-xr-xr-x jnldir
+# Verify instance did freeze during updates by running a checkhealth
+##FILTERED##... ... .. ..:..:.. 20.. : Initiating CHECKHEALTH operation on source server pid [##PID##] for secondary instance name [INSTANCE2]
+PID ##FILTERED##[##PID##] Source server is alive in ACTIVE mode
+Warning: Instance Freeze is ON
+##TEST_AWK   Freeze Comment: PID [0-9]* encountered JNLEXTEND; Instance frozen
 # Start receiver server so source server connects and opens journal file and exercise RENAMEFAIL codepath
 ==Executing MULTISITE_REPLIC 'STARTRCV INST1 INST2'==
 # Ensure source and receiver are in sync


### PR DESCRIPTION
We had the r124/ydb282srcsrvrerr subtest hang once (out of hundreds of test runs) in internal testing.
The hang was in the mumps process doing lots of updates with ydb_white_box_test_case_number set to 202.
Below is the C-stack of the process when it was hung.

 #0  0x76e15ca8 in __clock_nanosleep (clock_id=<optimized out>, flags=1, req=0x7edf9d2c, rem=0x0) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:40
 #1  0x760b9d70 in m_usleep (useconds=100000) at sr_unix/sleep.c:25
 #2  0x76102ee8 in wait_for_repl_inst_unfreeze_nocsa_jpl (jpl=0x3a1e20) at sr_port/anticipatory_freeze.h:489
 #3  0x76103338 in wait_for_repl_inst_unfreeze (csa=0x39f820) at sr_port/anticipatory_freeze.h:512
 #4  0x7610d1e4 in wcs_wtstart (region=0x3a1100, writes=0, cr_list_ptr=0x0, cr2flush=0x0) at sr_unix/wcs_wtstart.c:674
 #5  0x7639eb54 in process_deferred_stale () at sr_port/process_deferred_stale.c:97
 #6  0x763f65fc in t_commit_cleanup (status=cdb_sc_uperr, signal=150372794) at sr_port/t_commit_cleanup.c:309
 #7  0x763f2fe8 in t_ch (arg=150372794) at sr_port/t_ch.c:99
 #8  0x760b42d8 in rts_error_va (csa=0x39f820, argcnt=7, var=...) at sr_unix/rts_error.c:160
 #9  0x760b337c in rts_error_csa (csa=0x39f820, argcnt=7) at sr_unix/rts_error.c:92
 #10 0x7627f834 in jnl_file_lost (jpc=0x39ff20, jnl_stat=150372794) at sr_port/jnl_file_lost.c:83
 #11 0x76020f28 in jnl_file_extend (jpc=0x39ff20, total_jnl_rec_size=1936) at sr_unix/jnl_file_extend.c:324
 #12 0x76403bd0 in t_end (hist1=0x44c478, hist2=0x0, ctn=18446744071629176832) at sr_port/t_end.c:1292
 #13 0x7622ae04 in gvcst_put2 (val=0x3a2fb4, parms=0x7ee10784) at sr_port/gvcst_put.c:2640
 #14 0x7620b93c in gvcst_put (val=0x3a2fb4) at sr_port/gvcst_put.c:300
 #15 0x763652f0 in op_gvput (var=0x3a2fb4) at sr_port/op_gvput.c:74
 #16 0x76fcb59c in ?? ()

The process triggered a JNLEXTEND error just like the test expected it to. But as part of issuing that error,
it realized a database flush timer had popped while holding crit and so was about to handle that as soon as crit
got released. But that meant flushing dirty buffers to disk which hung because the instance was frozen (which
it would because of the JNLEXTEND error that is already included in the custom errors file).

Since this is a side effect that is not related to the purpose of this test, the fix is to bump the flush timer
from the default 1 second to a huge value (1 hour, the maximum) that way we avoid flush timers from popping
in when the JNLEXTEND error occurs.