### PR TITLE
com/expectinit.exp Implemented in v63004 subtests gtm8777, gtm8791, and gtm8909

### DIFF
--- a/com/expectinit.exp
+++ b/com/expectinit.exp
@@ -1,0 +1,54 @@
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+#
+# expectinit.exp is meant to be sourced from all test framework expect scripts in order
+# to set up each expect environment uniformly. This way test output does not depend upon
+# what the shell is like where the expect is called from.
+#
+#	USAGE:  source from within your expect script AFTER spawning your expect scripts shell
+#
+#		set timeout 60					#time out is set independently
+#		spawn /usr/local/bin/tcsh -f			#spawn shel first
+#		source $::env(gtm_tst)/com/expectinit.exp	#source expetinit.exp
+#
+# 	Note: environment variabls in .exp srcipts must be accessed with $::env(<var>)
+
+
+# Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
+expect -exact ">"
+send -- "stty cols 132\r"
+expect "stty cols 132\r"
+expect -exact ">"
+
+# Change shell prompt to something other than ">" as that is a substring of many YDB prompts
+# and can cause incorrect match later when we wait for the shell prompt.
+expect -exact ">"
+# Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
+#	send -- "set prompt=SHELL\r"
+#	expect -exact "SHELL"
+# But that will not work because it is possible the "expect" matches the SHELL from the "set prompt=SHELL" input.
+# To avoid this, we first store the "SHELL" string in a variable and use that to set the prompt.
+send -- "set shellprompt=SHELL\r"
+expect -exact ">"
+send -- "set prompt=\$shellprompt\r"
+expect -exact "SHELL"
+
+
+# Set uniform behaivor for handeling a timeout
+expect_after {
+	timeout { timeout_procedure }
+}
+
+proc timeout_procedure { } {
+	puts "timeout occurred"
+	exit -1
+}

--- a/com/expectinit.exp
+++ b/com/expectinit.exp
@@ -11,23 +11,30 @@
 #################################################################
 #
 # expectinit.exp is meant to be sourced from all test framework expect scripts in order
-# to set up each expect environment uniformly. This way test output does not depend upon
-# what the shell is like where the expect is called from.
+# to set up each expect environment uniformly.
 #
 #	USAGE:  source from within your expect script AFTER spawning your expect scripts shell
 #
 #		set timeout 60					#time out is set independently
-#		spawn /usr/local/bin/tcsh -f			#spawn shel first
-#		source $::env(gtm_tst)/com/expectinit.exp	#source expetinit.exp
+#		spawn /usr/local/bin/tcsh -f			#spawn shell first
+#		source $::env(gtm_tst)/com/expectinit.exp	#source expectinit.exp
 #
 # 	Note: environment variabls in .exp srcipts must be accessed with $::env(<var>)
+#       Note: expectinit.exp resets the shell prompt to "SHELL" so expecting the shell prompt should look like:
+#			This:	expect "SHELL"
+#	            Not this: 	expect ">"
 
 
-# Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
+# Have columns set to a high value of 132 as many callers have long lines
+#   and we do not want line wrapping to cause test failures.
+# Also note that the expect terminal width is inherited from the parent terminal
+#  from where the test is invoked and so setting this to 132 avoids false failures
+#  due to the parent terminal having an arbitrarily (small) terminal width.
 expect -exact ">"
 send -- "stty cols 132\r"
 expect "stty cols 132\r"
 expect -exact ">"
+
 
 # Change shell prompt to something other than ">" as that is a substring of many YDB prompts
 # and can cause incorrect match later when we wait for the shell prompt.
@@ -43,7 +50,7 @@ send -- "set prompt=\$shellprompt\r"
 expect -exact "SHELL"
 
 
-# Set uniform behaivor for handeling a timeout
+# Set uniform behaivor for handling a timeout
 expect_after {
 	timeout { timeout_procedure }
 }

--- a/v63004/outref/gtm8909.txt
+++ b/v63004/outref/gtm8909.txt
@@ -1,8 +1,8 @@
 spawn /usr/local/bin/tcsh -f
-> # Expect the shell prompt
-stty cols 132
-> # Expect the shell prompt
-# Start LKE help facility
+> stty cols 132
+> set shellprompt=SHELL
+> set prompt=$shellprompt
+SHELL# Start LKE help facility
 $gtm_dist/lke
 LKE> help
 Additional information available: 
@@ -13,8 +13,7 @@ Commands    Copyright   Introduction            Summary
 Topic? 
 # Exit LKE>
 LKE> exit
-> # Expect the shell prompt
-# Start DSE help facility
+SHELL# Start DSE help facility
 $gtm_dist/dse
 File  	##TEST_PATH##/mumps.dat
 Region	DEFAULT
@@ -27,8 +26,7 @@ Commands    Copyright   Operations  Summary
 Topic? 
 # Exit DSE>
 DSE> exit
-> # Expect the shell prompt
-# Start MUPIP help facility
+SHELL# Start MUPIP help facility
 $gtm_dist/mupip
 MUPIP> help
 Additional information available: 
@@ -40,6 +38,5 @@ Copyright   GDM         Introduction            Journaling  Replication
 Summary     
 Topic? 
 # Exit MUPIP>
-MUPIP> # Expect the shell prompt
-exit
-> 
+MUPIP> exit
+SHELL

--- a/v63004/u_inref/gtm8777.exp
+++ b/v63004/u_inref/gtm8777.exp
@@ -12,28 +12,7 @@
 #
 set timeout 120
 spawn /usr/local/bin/tcsh -f
-# Change shell prompt to something other than ">" as that is a substring of the LKE prompt "LKE>"
-# and can cause incorrect match later when we wait for the shell prompt.
-expect -exact ">"
-# Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
-#	send -- "set prompt=SHELL\r"
-#	expect -exact "SHELL"
-# But that will not work because it is possible the "expect" matches the SHELL from the "set prompt=SHELL" input
-# instead of from the SHELL prompt later spewed out by the shell. To avoid this, we first store the "SHELL" string
-# in a shell variable and use that variable in another line to set the prompt.
-send -- "set shellprompt=SHELL\r"
-expect -exact ">"
-send -- "set prompt=\$shellprompt\r"
-expect -exact "SHELL"
-
-expect_after {
-	timeout { timeout_procedure }
-}
-
-proc timeout_procedure { } {
-	puts "timeout occurred"
-	exit -1
-}
+source $::env(gtm_tst)/com/expectinit.exp
 
 #Start mumps -direct
 send -- "\$gtm_dist/mumps -direct\r"

--- a/v63004/u_inref/gtm8791.exp
+++ b/v63004/u_inref/gtm8791.exp
@@ -12,19 +12,8 @@
 #
 set timeout 60
 spawn /usr/local/bin/tcsh -f
-# Change shell prompt to something other than ">" as that is a substring of the LKE prompt "LKE>"
-# and can cause incorrect match later when we wait for the shell prompt.
-expect -exact ">"
-# Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
-#	send -- "set prompt=SHELL\r"
-#	expect -exact "SHELL"
-# But that will not work because it is possible the "expect" matches the SHELL from the "set prompt=SHELL" input
-# instead of from the SHELL prompt later spewed out by the shell. To avoid this, we first store the "SHELL" string
-# in a shell variable and use that variable in another line to set the prompt.
-send -- "set shellprompt=SHELL\r"
-expect -exact ">"
-send -- "set prompt=\$shellprompt\r"
-expect -exact "SHELL"
+source $::env(gtm_tst)/com/expectinit.exp
+
 
 expect_after {
 	timeout { timeout_procedure }

--- a/v63004/u_inref/gtm8909.exp
+++ b/v63004/u_inref/gtm8909.exp
@@ -12,29 +12,27 @@
 #
 set timeout 60
 set promptList {LKE DSE MUPIP}
-
 spawn /usr/local/bin/tcsh -f
+source $::env(gtm_tst)/com/expectinit.exp
 
-expect_after {
-	timeout { timeout_procedure }
-}
-
-proc timeout_procedure { } {
-	puts "timeout occurred"
-	exit -1
-}
-
-expect -exact ">"
-puts "# Expect the shell prompt"
-
-# Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
-send -- "stty cols 132\r"
-expect "stty cols 132\r"
+#expect_after {
+#	timeout { timeout_procedure }
+#}
+#
+#proc timeout_procedure { } {
+#	puts "timeout occurred"
+#	exit -1
+#}
+#
+#expect -exact ">"
+#puts "# Expect the shell prompt"
+#
+## Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
+#send -- "stty cols 132\r"
+#expect "stty cols 132\r"
 
 
 foreach prompt $promptList {
-	expect -exact ">"
-	puts "# Expect the shell prompt"
 	puts "# Start $prompt help facility"
 	send -- "\$gtm_dist/[string tolower $prompt]\r"
 	expect -exact "$prompt>"
@@ -47,7 +45,5 @@ foreach prompt $promptList {
 	puts "\n# Exit $prompt>"
 	expect -exact "$prompt>"
 	send -- "exit\r"
+	expect "SHELL"
 	}
-
-puts "# Expect the shell prompt"
-expect -exact ">"


### PR DESCRIPTION
Add com/expectinit.exp tool to uniformly setup expect scripts in the test framework. Implement com/expectinit.exp in all v63004 expect scripts (gtm8777, gtm8791, gtm8909).