### PR TITLE
Fix occasional v63002/gtm8165 subtest failure due to pid wrapping around 32K

### DIFF
--- a/v63002/inref/gtm8165.m
+++ b/v63002/inref/gtm8165.m
@@ -48,7 +48,7 @@ locktimeout
 
 lockchild
 	set pid="locktimeout.txt"
-	open pid
+	open pid:(newversion)
 	use pid
 	write $job
 	close pid
@@ -105,7 +105,7 @@ writeslashpass
 
 passchild
 	set pid2="writeslashpass.txt"
-	open pid2
+	open pid2:(newversion)
 	use pid2
 	write $job
 	close pid2
@@ -143,7 +143,7 @@ writeslashaccept
 
 acceptchild
 	set pid2="writeslashaccept.txt"
-	open pid2
+	open pid2:(newversion)
 	use pid2
 	write $job
 	close pid2
@@ -182,7 +182,7 @@ writeslashtls
 
 tlschild
 	set pid2="writeslashtls.txt"
-	open pid2
+	open pid2:(newversion)
 	use pid2
 	write $job
 	close pid2


### PR DESCRIPTION
In one test run, we saw the following failure
```
> 8: Operation not permitted
```
Turns out this is because the test tried to do a "kill -9" of pid # 8 which was a valid root owned
pid and we did not have permissions to kill that process.

The reason why we tried to kill pid 8 was because the below file had 2 pids instead of just one.
```
> cat writeslashpass.txt
335
8
```
The M program that creates this file writes just one pid to the file.
```
gtm8165.m
    106 passchild
    107         set pid2="writeslashpass.txt"
    108         open pid2
    109         use pid2
    110         write $job
    111         close pid2
```
Turns out passchild^gtm8165 is invoked twice in the course of the test. And it opens the file at line 108
with no other open command parameters. This means when it is called the second time, it is going to open
a pre-existing file with a non-zero pid and overwrite that file with the new pid. If it so happens that
the first pid had 5 characters and the second pid had 3 characters (possible if the first invocation pid
was close to 32K and a pid wraps back to a small 3-digit number before the second invocation), the overwrite
of the second pid will result in a 3-byte second pid followed by a new line character followed by the
5th character of the pid from the first invocation. That can result in 2 lines like we see above.

The fix is to open the file with "newversion" parameter so it is recreated in each invocation.
A similar fix is needed to a few other labels in the same M program and is now done.