### PR TITLE
Fix com/expectinit.exp failure on certain subtests due to redundant expect command

### DIFF
--- a/com/expectinit.exp
+++ b/com/expectinit.exp
@@ -38,7 +38,6 @@ expect -exact ">"
 
 # Change shell prompt to something other than ">" as that is a substring of many YDB prompts
 # and can cause incorrect match later when we wait for the shell prompt.
-expect -exact ">"
 # Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
 #	send -- "set prompt=SHELL\r"
 #	expect -exact "SHELL"

--- a/com/runcmd.exp
+++ b/com/runcmd.exp
@@ -19,33 +19,8 @@
 # Note: Timeout set at 1 hour below since an arbitrary input script (<cmd>) is executed
 # and could take a lot longer than the usual 1 minute that we have for expect command timeout.
 set timeout 3600
-
 spawn /usr/local/bin/tcsh -f
-
-expect_after {
-	timeout { timeout_procedure }
-}
-proc timeout_procedure { } {
-	puts "timeout occurred"
-	exit -1
-}
-# Change shell prompt to something other than ">" as that is a substring of prompts like "LKE>", "YDB>", "DSE>", "MUPIP>" etc.
-# and can cause incorrect match later when we wait for the shell prompt.
-expect -exact ">"
-
-# Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
-#	send -- "set prompt=SHELL\r"
-#	expect -exact "SHELL"
-# But that will not work because it is possible the "expect" matches the SHELL from the "set prompt=SHELL" input
-# instead of from the SHELL prompt later spewed out by the shell. To avoid this, we first store the "SHELL" string
-# in a shell variable and use that variable in another line to set the prompt.
-send -- "set shellprompt=SHELL\r"
-expect -exact ">"
-send -- "set prompt=\$shellprompt\r"
-expect -exact "SHELL"
-
-send -- "set prompt=\$shellprompt\r"
-expect -exact "SHELL"
+source $::env(gtm_tst)/com/expectinit.exp
 
 # Send the first argument as a command
 set cmd [lindex $argv 0]
@@ -54,4 +29,3 @@ send -- "\r"
 
 # Wait for shell prompt to return
 expect -exact "SHELL"
-

--- a/r122/u_inref/SECNOTSUPPLEMENTARYtest.csh
+++ b/r122/u_inref/SECNOTSUPPLEMENTARYtest.csh
@@ -42,7 +42,6 @@ else
 	 set cmds="$cmd1; $cmd2"
 
 	(expect -d $gtm_tst/com/runcmd.exp "$cmds" > expect_SECNOTSUPPLEMENTARY.out) >& expect_SECNOTSUPPLEMENTARY.dbg
-	#(expect -d $gtm_tst/$tst/u_inref/SECNOTSUPPLEMENTARYtest.exp > expect_SECNOTSUPPLEMENTARY.out) >& expect_SECNOTSUPPLEMENTARY.dbg
 	if ($status) then
 		echo "EXPECT-E-FAIL : expect returned non-zero exit status" >> $outputFile
 		echo '' >> $outputFile

--- a/r122/u_inref/ydb210.csh
+++ b/r122/u_inref/ydb210.csh
@@ -38,7 +38,6 @@ foreach testDir ("NULLCOLLtest" "REPLOFFJNLONtest" "REPLINSTNOHISTtest" "SECNOTS
 
 	echo "RUNNING $testDir.csh IN A NEW TERMINAL"
 	echo "----------------------------------------------------------"
-	#(expect -d $gtm_tst/$tst/u_inref/ydb210.exp > expect.out) >& expect.dbg
 	set cmd='echo "Running: $errorTest"; '
 	set cmd="$cmd"'$errorTest; '
 

--- a/v63002/u_inref/gtm8694.exp
+++ b/v63002/u_inref/gtm8694.exp
@@ -13,22 +13,8 @@
 set timeout 60
 
 spawn /usr/local/bin/tcsh -f
+source $::env(gtm_tst)/com/expectinit.exp
 
-expect_after {
-	timeout { timeout_procedure }
-}
-
-proc timeout_procedure { } {
-	puts "timeout occurred"
-	exit -1
-}
-
-expect -exact ">"
-puts "# Expect the shell prompt"
-
-# Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
-send -- "stty cols 132\r"
-expect "stty cols 132\r"
 send -- "\$ydb_dist/mumps -dir\r"
 expect "YDB>"
 send "use \$principal:(cenable)\r"
@@ -37,6 +23,6 @@ puts "#<CTRL-C>"
 send -- "\x03\r"
 expect "YDB>"
 send "halt\r"
-expect ">"
+expect "SHELL"
 
 

--- a/v63003/outref/gtm8889.txt
+++ b/v63003/outref/gtm8889.txt
@@ -3,10 +3,9 @@
 # Terminal Display:
 
 spawn /usr/local/bin/tcsh -f
-> # Expect the shell prompt
-set shellprompt=SHELL
+> stty cols 132
+> set shellprompt=SHELL
 > set prompt=$shellprompt
-SHELLstty cols 132
 SHELLYDB
 $ydb_dist/mumps -dir
 YDB>zhelp

--- a/v63003/u_inref/gtm8787.exp
+++ b/v63003/u_inref/gtm8787.exp
@@ -13,22 +13,8 @@
 set timeout 60
 
 spawn /usr/local/bin/tcsh -f
+source $::env(gtm_tst)/com/expectinit.exp
 
-expect_after {
-	timeout { timeout_procedure }
-}
-
-proc timeout_procedure { } {
-	puts "timeout occurred"
-	exit -1
-}
-
-
-# Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
-send -- "stty cols 132\r"
-expect "stty cols 132\r"
-
-expect -exact ">"
 send -- "\$MUPIP Journal -Extract=-stdout -forward mumps.mjl & \r"
 expect -exact "x(10)"
 send -- "exit \r"

--- a/v63003/u_inref/gtm8889.exp
+++ b/v63003/u_inref/gtm8889.exp
@@ -13,35 +13,36 @@
 set timeout 60
 
 spawn /usr/local/bin/tcsh -f
+source $::env(gtm_tst)/com/expectinit.exp
 
-expect_after {
-	timeout { timeout_procedure }
-}
-
-proc timeout_procedure { } {
-	puts "timeout occurred"
-	exit -1
-}
-
-expect -exact ">"
-puts "# Expect the shell prompt"
-# Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
-#	send -- "set prompt=SHELL\r"
-#	expect -exact "SHELL"
-# But that will not work because it is possible the "expect" matches the SHELL from the "set prompt=SHELL" input
-# instead of from the SHELL prompt later spewed out by the shell. To avoid this, we first store the "SHELL" string
-# in a shell variable and use that variable in another line to set the prompt.
-send -- "set shellprompt=SHELL\r"
-expect -exact ">"
-send -- "set prompt=\$shellprompt\r"
-expect -exact "SHELL"
-
-
-# Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
-send -- "stty cols 132\r"
-expect "stty cols 132\r"
-
-expect -exact "SHELL"
+#expect_after {
+#	timeout { timeout_procedure }
+#}
+#
+#proc timeout_procedure { } {
+#	puts "timeout occurred"
+#	exit -1
+#}
+#
+#expect -exact ">"
+#puts "# Expect the shell prompt"
+## Note: Changing the shell prompt to SHELL might seem easily achieved as follows.
+##	send -- "set prompt=SHELL\r"
+##	expect -exact "SHELL"
+## But that will not work because it is possible the "expect" matches the SHELL from the "set prompt=SHELL" input
+## instead of from the SHELL prompt later spewed out by the shell. To avoid this, we first store the "SHELL" string
+## in a shell variable and use that variable in another line to set the prompt.
+#send -- "set shellprompt=SHELL\r"
+#expect -exact ">"
+#send -- "set prompt=\$shellprompt\r"
+#expect -exact "SHELL"
+#
+#
+## Have columns higher than 80 as that can cause test failures on lines that are just above 80 columns in length
+#send -- "stty cols 132\r"
+#expect "stty cols 132\r"
+#
+#expect -exact "SHELL"
 puts "YDB"
 send -- "\$ydb_dist/mumps -dir\r"
 expect -exact "YDB>"


### PR DESCRIPTION
Implement com/expectinit.exp in com/runcmd.exp. Remove useless commented code in ydb210.csh and SECNOTSUPPLEMENTARYtests.csh. Remove redundant expect of '>' from com/expectinit.exp which would cause expect script failure for some subtests that use the script