### PR TITLE
Updated v63002/gtm8694 subtest 

### DIFF
--- a/v63002/outref/gtm8694.txt
+++ b/v63002/outref/gtm8694.txt
@@ -154,3 +154,11 @@ PIPE_OPEN acted as expected
 DIRECT_MODE acted as expected
 DSE acted as expected
 TRIGGER_MOD acted as expected
+
+#----------------------------------------------------------------------
+
+TESTING A RANDOM FUNCTION WHEN THERE IS A SYNTAX ERROR IN RESTRICT.TXT AND CHECKING THE SYSLOG
+
+-r--r--r-- ydb_temp_dist/restrict.txt
+# CHECKING THE SYSLOG
+##TEST_AWK%YDB-E-RESTRICTSYNTAX, Syntax error in file ##TEST_PATH##/ydb_temp_dist/restrict.txt at line number 1. All facilities restricted for process. -- generated from 0x.*

--- a/v63002/u_inref/gtm8694.csh
+++ b/v63002/u_inref/gtm8694.csh
@@ -254,12 +254,11 @@ $gtm_tst/com/lsminusl.csh $ydb_dist/restrict.txt | $tst_awk '{print $1,$9}'
 $MUPIP trigger -triggerfile=trigger.trg >>& trigger.txt
 set rand='$'`$gtm_tst/com/genrandnumbers.csh 1 1 7`
 set fn=`$tst_awk "{print $rand}" fnlist.txt`
-set t1 = `date +"%b %e %H:%M:%S"`
+set t = `date +"%b %e %H:%M:%S"`
 $ydb_dist/mumps -run $fn^gtm8694>&output.txt
-set t2 = `date +"%b %e %H:%M:%S"`
 # Included to avoid the syntax error in the syslog created when calling getoper (which invokes an m function)
-sleep 1
-$gtm_tst/com/getoper.csh "$t1" "$t2" getoper.txt
+rm $ydb_dist/restrict.txt
+$gtm_tst/com/getoper.csh "$t" "" getoper.txt "" "RESTRICTSYNTAX"
 echo "# CHECKING THE SYSLOG"
 $grep %YDB-E-RESTRICTSYNTAX getoper.txt |& sed  's/.*%YDB-E-RESTRICTSYNTAX/%YDB-E-RESTRICTSYNTAX/'
 $gtm_tst/com/dbcheck.csh >>& dbcheck.out

--- a/v63002/u_inref/gtm8694.csh
+++ b/v63002/u_inref/gtm8694.csh
@@ -37,6 +37,7 @@ TRIGGER_MOD
 EOF
 # Not including CENABLE in this list because of logistics reasons
 echo "BREAK ZBREAK ZCMDLINE ZEDIT ZSYSTEM PIPE_OPEN DIRECT_MODE DSE TRIGGER_MOD">restrictlist.txt
+echo "breakfn zbreakfn zcmdlnefn zeditfn zsystemfn pipefn trigmodfn">fnlist.txt
 chmod -w $ydb_dist/restrict.txt
 
 cat > dummy.txt <<EOF
@@ -239,5 +240,26 @@ foreach restrict (`cat restrictlist.txt`)
 		endif
 	endif
 end
-
+echo ""
+echo "#----------------------------------------------------------------------"
+echo ""
+echo "TESTING A RANDOM FUNCTION WHEN THERE IS A SYNTAX ERROR IN RESTRICT.TXT AND CHECKING THE SYSLOG"
+echo ""
+rm $ydb_dist/restrict.txt
+cat > $ydb_dist/restrict.txt << EOF
+syntax error
+EOF
+chmod -w $ydb_dist/restrict.txt
+$gtm_tst/com/lsminusl.csh $ydb_dist/restrict.txt | $tst_awk '{print $1,$9}'
+$MUPIP trigger -triggerfile=trigger.trg >>& trigger.txt
+set rand='$'`$gtm_tst/com/genrandnumbers.csh 1 1 7`
+set fn=`$tst_awk "{print $rand}" fnlist.txt`
+set t1 = `date +"%b %e %H:%M:%S"`
+$ydb_dist/mumps -run $fn^gtm8694>&output.txt
+set t2 = `date +"%b %e %H:%M:%S"`
+# Included to avoid the syntax error in the syslog created when calling getoper (which invokes an m function)
+sleep 1
+$gtm_tst/com/getoper.csh "$t1" "$t2" getoper.txt
+echo "# CHECKING THE SYSLOG"
+$grep %YDB-E-RESTRICTSYNTAX getoper.txt |& sed  's/.*%YDB-E-RESTRICTSYNTAX/%YDB-E-RESTRICTSYNTAX/'
 $gtm_tst/com/dbcheck.csh >>& dbcheck.out


### PR DESCRIPTION
Added a case to the subtest to test that a RESTRICTSYNTAX error is produced in the syslog when an m program is called and there is a syntax error in restrict.txt