### PR TITLE
Cosmetic changes to instream.csh in v63002/v63003/v63004/v63005 subtests

### DIFF
--- a/v63002/instream.csh
+++ b/v63002/instream.csh
@@ -27,21 +27,20 @@
 # gtm8733	    [vinay] Tests $ZCONVERT operates appropriately in UTF-8 NOBADCHAR mode
 # gtm8718	    [vinay] Tests setting $ZROUTINES to an invalid string leaves the previous value of $ZROUTINES as it is
 # gtm8616	    [vinay] Tests argumentless MUPIP RUNDOWN logs a message in the syslog containing the pid, uid and current working directory
-# gtm8740	    [vinay] Tests custom error files can be loaded without a full shutdown
 # gtm8766	    [vinay] Tests MUPIP and GDE behave appropriately when trying to set global buffer values too high
 # gtm5754	    [vinay] Tests that certain XECUTE literals compile at run time while the rest precompile
 # gtm8165	    [vinay] Tests a WRITE / timeout greater than $gtm_tpnotacidtime when $TRESTART>2 produces a TPNOTACID error in the syslog
 # gtm6657	    [vinay] Tests MUPIP BACKUP -BKUPDBJNL=OFF does not adjust the journaling state for a database with journaling disabled
+# gtm8740	    [vinay] Tests custom error files can be loaded without a full shutdown
 #-------------------------------------------------------------------------------------
 
 echo "v63002 test starts..."
 
 # List the subtests separated by spaces under the appropriate environment variable name
 setenv subtest_list_common     ""
-setenv subtest_list_non_replic "gtm8694 gtm8281 gtm5178 gtm8717 gtm8644 gtm8760 gtm5250 gtm8736 gtm8718 gtm8616 gtm8766 gtm5754"
-setenv subtest_list_non_replic "gtm8694 gtm8281 gtm5178 gtm8717 gtm8644 gtm8760 gtm5250 gtm8736 gtm8698 gtm8711 gtm8733 gtm8718 gtm8616 gtm8766 gtm5754 gtm8165 gtm6657"
+setenv subtest_list_non_replic "gtm8694 gtm8281 gtm5178 gtm8717 gtm8644 gtm8760 gtm5250 gtm8736 gtm8698 gtm8711 gtm8733"
+setenv subtest_list_non_replic "$subtest_list_non_replic gtm8718 gtm8616 gtm8766 gtm5754 gtm8165 gtm6657"
 setenv subtest_list_replic     "gtm8740"
-
 
 if ($?test_replic == 1) then
 	setenv subtest_list "$subtest_list_common $subtest_list_replic"

--- a/v63003/instream.csh
+++ b/v63003/instream.csh
@@ -14,6 +14,9 @@
 #-------------------------------------------------------------------------------------
 # List of subtests of the form "subtestname [author] description"
 #-------------------------------------------------------------------------------------
+# gtm8795	    [vinay] Tests journal files update after MUPIP FREEZE -ON -ONLINE
+# gtm8794	    [vinay] Tests copies of a database file can be used after a MUPIP RUNDOWN -OVERRIDE and MUPIP FREEZE -OFF on the copy
+# gtm8850	    [vinay] Tests GTM processes properly detach from a database when a FREEZE -ONLINE is in place
 # gtm8788           [nars]  Test that BLKTOODEEP error lines are excluded from object file (GTM-8788 fixed in GT.M V6.3-003)
 # gtm7986	    [vinay] Test that a line of over 8192 bytes produces an LSINSERTED warning
 # gtm8186	    [vinay] Test DO, GOTO and ZGOTO can take offset without a label
@@ -22,7 +25,6 @@
 # gtm8617	    [vinay] Tests MUPIP SET command of STDNULLCOLL and NULL_SUBSCRIPTS
 # gtm4212	    [vinay] Tests that MUPIP BACKUP produces a FILENAMETOOLONG error for paths >=255 characters
 # gtm8732nr	    [vinay] Tests the valid inputs of the flag DEFER_TIME for the MUPIP SET command
-# gtm8732r	    [vinay] Tests the valid inputs of HELPERS and LOG_INTERVAL for the MUPIP REPLICATE command
 # gtm8767	    [vinay] Tests the functionality of HARD_SPIN_COUNT, SPIN_SLEEP_MASK and SPIN_SLEEP_LIMIT for MUPIP SET
 # gtm8735	    [vinay] Tests the functionality of the READ_ONLY flag in MUPIP SET
 # gtm8779	    [vinay] Tests changing Freeze produces a DBFREEZEON/DBFREEZEOFF message in the system
@@ -34,35 +36,32 @@
 # gtm8856	    [vinay] Tests literal optimizations that can result in errors at compile time are deferred if done inside XECUTE
 # gtm8857	    [vinay] Tests patterns exceeding the size GTM supports produces a PATMAXLEN error
 # gtm8854	    [vinay] Tests syntax error in the argument of a FALSE postconditional is handled appropriately
-# gtm8795	    [vinay] Tests journal files update after MUPIP FREEZE -ON -ONLINE
 # gtm8839	    [vinay] Tests $DEVICE returns the complete error message
 # gtm8781	    [vinay] Tests ZSYSTEM does not produce memory leaks
 # gtm8849	    [vinay] Shows help databases have QDBRUNDOWN and NOGVSTATS characteristics
-# gtm8794	    [vinay] Tests copies of a database file can be used after a MUPIP RUNDOWN -OVERRIDE and MUPIP FREEZE -OFF on the copy
 # gtm8790	    [vinay] Tests $REFERENCE will maintain extended reference for the first reference when stat sharing is enabled
 # gtm8587	    [vinay] Tests $KEY is maintained for sequential devices and $DEVICE is maintained for certain error descriptions
 # gtm8855	    [vinay] Tests GTM correctly cleans up buffers allocated due to a missing global directory
-# gtm8850	    [vinay] Tests GTM processes properly detach from a database when a FREEZE -ONLINE is in place
 # gtm8847	    [vinay] Tests the functionality of $ZSTRPLLIM
 # gtm8801	    [vinay] Tests ^%YGBLSTAT works on a cmake build
 # gtm8842	    [vinay] Tests TRIGGER_MOD appropriately restricts ZBREAK and ZSTEP
 # gtm8858	    [vinay] Demonstrates the improved available information in cases of apparent database integrity issues
-# gtm8844	    [vinay] Tests the functionality of HALT and ZHALT in trigger logic and when restricted
 # gtm8805	    [vinay] Tests YottaDB manages LOCK concurrency correctly when checking for abandoned locks
 # gtm8680	    [vinay] Tests YDB does not slow down significantly when holding a large number of locks and/or processes
+# gtm8732r	    [vinay] Tests the valid inputs of HELPERS and LOG_INTERVAL for the MUPIP REPLICATE command
+# gtm8844	    [vinay] Tests the functionality of HALT and ZHALT in trigger logic and when restricted
 # gtm8182	    [jake]  Tests the updating of globals belonging to a different source instance using global references
 #-------------------------------------------------------------------------------------
 
 echo "v63003 test starts..."
 
 # List the subtests separated by spaces under the appropriate environment variable name
-setenv subtest_list_common     ""
+setenv subtest_list_common     "gtm8795 gtm8794 gtm8850"
 setenv subtest_list_non_replic "gtm8788 gtm7986 gtm8186 gtm8804 gtm8832 gtm8617 gtm4212 gtm8732nr gtm8767 gtm8735 gtm8779 gtm8798"
-setenv subtest_list_non_replic "$subtest_list_non_replic gtm8846 gtm8780 gtm8787 gtm8889 gtm8856 gtm8857 gtm8854 gtm8795 gtm8839"
-setenv subtest_list_non_replic "$subtest_list_non_replic gtm8781 gtm8849 gtm8794 gtm8790 gtm8587 gtm8855 gtm8850 gtm8847 gtm8801"
+setenv subtest_list_non_replic "$subtest_list_non_replic gtm8846 gtm8780 gtm8787 gtm8889 gtm8856 gtm8857 gtm8854 gtm8839"
+setenv subtest_list_non_replic "$subtest_list_non_replic gtm8781 gtm8849 gtm8790 gtm8587 gtm8855 gtm8847 gtm8801"
 setenv subtest_list_non_replic "$subtest_list_non_replic gtm8842 gtm8858 gtm8805 gtm8680"
-setenv subtest_list_replic     "gtm8732r gtm8795 gtm8794 gtm8850 gtm8844 gtm8182"
-
+setenv subtest_list_replic     "gtm8732r gtm8844 gtm8182"
 
 if ($?test_replic == 1) then
 	setenv subtest_list "$subtest_list_common $subtest_list_replic"

--- a/v63003/outref/outref.txt
+++ b/v63003/outref/outref.txt
@@ -1,4 +1,7 @@
 v63003 test starts...
+PASS from gtm8795
+PASS from gtm8794
+PASS from gtm8850
 ##SUSPEND_OUTPUT REPLIC
 PASS from gtm8788
 PASS from gtm7986
@@ -19,17 +22,14 @@ PASS from gtm8889
 PASS from gtm8856
 PASS from gtm8857
 PASS from gtm8854
-PASS from gtm8795
 ##SUSPEND_OUTPUT PRO
 PASS from gtm8839
 ##ALLOW_OUTPUT PRO
 PASS from gtm8781
 PASS from gtm8849
-PASS from gtm8794
 PASS from gtm8790
 PASS from gtm8587
 PASS from gtm8855
-PASS from gtm8850
 PASS from gtm8847
 PASS from gtm8801
 PASS from gtm8842
@@ -41,9 +41,6 @@ PASS from gtm8680
 ##ALLOW_OUTPUT REPLIC
 ##SUSPEND_OUTPUT NON_REPLIC
 PASS from gtm8732r
-PASS from gtm8795
-PASS from gtm8794
-PASS from gtm8850
 PASS from gtm8844
 PASS from gtm8182
 ##ALLOW_OUTPUT NON_REPLIC

--- a/v63004/instream.csh
+++ b/v63004/instream.csh
@@ -21,7 +21,6 @@
 # gtm8791  [jake]  Tests that <ctrl-z> no longer causes segmentation violation
 # gtm8699  [jake]  Tests that $VIEW("STATSHARE",<region>) returns 1 if the process is sharing DB stats and 0 otherwise
 # gtm8202  [jake]  Tests the functionality of the -SEQNO qualifier for the mupip journal -extract command
-# gtm5730  [jake]  Tests that the update process now logs record types with a corresponding, non-numerical, description
 # gtm1042  [jake]  Tests the that env variable gtm_mstack_size sets the size of the M stack as expected
 # gtm8891  [vinay] Tests that <side-effect-expression><pure-Boolean-operator>$SELECT(0:side-effect-expression)) sequence produces a SELECTFALSE runtime error
 # gtm8894  [vinay] Tests that $zreldate outputs in the form YYYYMMDD 24:60
@@ -30,11 +29,12 @@
 # gtm8923  [jake]  Tests the READ * and WRITE * commands no longer produce errors or incorrect output for files or sockets with CHSET={UTF-16,UTF-16BE,UTF-16LE}
 # gtm8903  [jake]  Tests $SELECT(1:,:) function call for errors when global references are present
 # gtm3146  [jake]  Tests that changes to alias and path settings no longer disrupt system() calls within MUPIP BACKUP command calls
-# gtm8906  [nars]  Test that MUPIP JOURNAL RECOVER/ROLLBACK handle large amounts of journal data (more than 55 million updates)
-# gtm8916  [jake]  Tests that the reciever process always restarts properly after the update process is killed. Previously the reciever process would often hang.
 # gtm8777  [jake]  Test that QUIET and QCALL calls to %GCE, %GSE, %RCE, and %RSE only output results for globals/routines that contain a match
 # gtm7483  [jake]  Test that MUPIP INTEG issues a DBKEYMX error in case of a long key name stored in the Directory Tree
 # gtm8900  [jake]  Test the functionality of MUPIP SET -[NO]ENCRYPTABLE when GNUPGHOME and/or gtm_passwd are properly defined or not
+# gtm5730  [jake]  Tests that the update process now logs record types with a corresponding, non-numerical, description
+# gtm8906  [nars]  Test that MUPIP JOURNAL RECOVER/ROLLBACK handle large amounts of journal data (more than 55 million updates)
+# gtm8916  [jake]  Tests that the reciever process always restarts properly after the update process is killed. Previously the reciever process would often hang.
 #------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 echo "v63004 test starts..."

--- a/v63005/instream.csh
+++ b/v63005/instream.csh
@@ -18,10 +18,10 @@
 # gtm8962	     [vinay]  Tests ZSHOW "I" shows $ZPIN and $ZPOUT even if they are the same as $PRINCIPAL
 # gtm8961	     [vinay]  Tests the path reported by ZSHOW "D", $KEY and $ZSOCKET("","LOCALADDRESS",) for local sockets passed by JOB or WRITE /PASS is correct
 # gtm8941	     [vinay]  Tests LKE recognizes the full keyword for the -CRITICAL qualifier
-# gtm8877	     [vinay]  Tests the functionality of ZSYSTEM_FILTER and PIPE_FILTER
-# gtm8930	     [jake]   Tests the $VIEW("JNLPOOL") output for unopened/opened JNLPOOL and undefined replication instance file
+# gtm8980 	     [jake]   Tests VIEW & $VIEW for avoiding sig-11 in certain rare use cases and for changes in certain output values.
 # gtm5059	     [jake]   Tests new gtm_mstack_crit_threshold variable for setting which percentage of the mstack memory is used before a STACKCRIT error is issued
 # gtm8943	     [vinay]  Tests ZGOTO 0 returns to the invoking C routine on call ins
+# gtm8930	     [jake]   Tests the $VIEW("JNLPOOL") output for unopened/opened JNLPOOL and undefined replication instance file
 #----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 echo "v63005 test starts..."


### PR DESCRIPTION
The comment lines describing the purpose of each subtest are reordered now to be in the
same order as how the subtests are ordered in subtest_list_non_replic/subtest_list_replic.

Also used subtest_list_common wherever appropriate (if a subtest run -replic and not).

And reinserted a comment line about gtm8980 that was lost in a prior commit.

Fixed outref.txt wherever necessary.