### PR TITLE
Fix v63005/gtm8941 subtest failure on ARM (32-bit build has different lock space layout)

### DIFF
--- a/v63005/outref/gtm8941.txt
+++ b/v63005/outref/gtm8941.txt
@@ -1,19 +1,19 @@
 # Running the command $ydb_dist/lke show -crit
-%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/160; LOCK slots in use: 0/120; name space not full
+##TEST_AWK%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/(160|213); LOCK slots in use: 0/(120|184); name space not full
 %YDB-I-NOLOCKMATCH, No matching locks were found in DEFAULT
 %YDB-I-LOCKSPACEUSE, Estimated free lock space: 100% of 40 pages
 
 # Running the command $ydb_dist/lke show -critical
-%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/160; LOCK slots in use: 0/120; name space not full
+##TEST_AWK%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/(160|213); LOCK slots in use: 0/(120|184); name space not full
 %YDB-I-NOLOCKMATCH, No matching locks were found in DEFAULT
 %YDB-I-LOCKSPACEUSE, Estimated free lock space: 100% of 40 pages
 
 # Running the command $ydb_dist/lke show -nocrit
-%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/160; LOCK slots in use: 0/120; name space not full
+##TEST_AWK%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/(160|213); LOCK slots in use: 0/(120|184); name space not full
 %YDB-I-NOLOCKMATCH, No matching locks were found in DEFAULT
 %YDB-I-LOCKSPACEUSE, Estimated free lock space: 100% of 40 pages
 
 # Running the command $ydb_dist/lke show -nocritical
-%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/160; LOCK slots in use: 0/120; name space not full
+##TEST_AWK%YDB-I-LOCKSPACEINFO, Region: DEFAULT: processes on queue: 0/(160|213); LOCK slots in use: 0/(120|184); name space not full
 %YDB-I-NOLOCKMATCH, No matching locks were found in DEFAULT
 %YDB-I-LOCKSPACEUSE, Estimated free lock space: 100% of 40 pages


### PR DESCRIPTION
Change reference file to allow for both 64-bit and 32-bit lock space layouts.