### PR TITLE
[#338] Fix various tests now that geteuid executable is removed from the distribution

### DIFF
--- a/com/determine_exe_name.csh
+++ b/com/determine_exe_name.csh
@@ -15,7 +15,7 @@
 
 ps -p $1 | tail -n 1 >! $2	# BYPASSOK ps/tail : used by tools scripts
 set pname = ""
-foreach exe_name ( mumps mupip dbcertify dse ftok geteuid gtcm_gnp_server gtcm_pkdisp gtcm_play gtcm_server gtcm_shmclean gtmsecshr libyottadb.so libgtmshr.so lke semstat2)
+foreach exe_name ( mumps mupip dbcertify dse ftok gtcm_gnp_server gtcm_pkdisp gtcm_play gtcm_server gtcm_shmclean gtmsecshr libyottadb.so libgtmshr.so lke semstat2)
 	grep $exe_name $2 >& /dev/null # BYPASSOK grep : used by tool scripts
 	if (! $status) then
 		set pname = "$gtm_exe/$exe_name"

--- a/io/inref/gtm7964.m
+++ b/io/inref/gtm7964.m
@@ -1,6 +1,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;								;
-;	Copyright 2014 Fidelity Information Services, Inc	;
+; Copyright 2014 Fidelity Information Services, Inc		;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
 ;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
@@ -22,8 +25,8 @@ gtm7964
 	open a:(comm="$ integ -file mumps.dat":parse)::"pipe"
 	write "open a:(comm=""$/ integ -file mumps.dat"":parse)::""pipe""",!
 	open a:(comm="$/ integ -file mumps.dat":parse)::"pipe"
-	write "open a:(comm=""$gtm_dist/geteuid"":parse:readonly)::""pipe""",!
-	open a:(comm="$gtm_dist/geteuid":parse:readonly)::"pipe"
+	write "open a:(comm=""id -un | sed 's/'$user'/other/g'"":parse:readonly)::""pipe""",!
+	open a:(comm="id -un | sed 's/'$user'/other/g'":parse:readonly)::"pipe"
 	use a
 	read x
 	use $P

--- a/io/outref/gtm7964.txt
+++ b/io/outref/gtm7964.txt
@@ -19,7 +19,7 @@ open a:(comm="$ integ -file mumps.dat":parse)::"pipe"
 STAT=gtm7964+11^gtm7964,%YDB-E-DEVOPENFAIL, Error opening PP,%YDB-I-TEXT, Invalid command string: $
 open a:(comm="$/ integ -file mumps.dat":parse)::"pipe"
 STAT=gtm7964+13^gtm7964,%YDB-E-DEVOPENFAIL, Error opening PP,%YDB-I-TEXT, Invalid command string: $/
-open a:(comm="$gtm_dist/geteuid":parse:readonly)::"pipe"
+open a:(comm="id -un | sed 's/'$user'/other/g'":parse:readonly)::"pipe"
 other
 open a:(comm="/bin/cat | nl":parse)::"pipe"
      1	one

--- a/manual_tests/u_inref/c002916.csh
+++ b/manual_tests/u_inref/c002916.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2012-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -55,7 +58,7 @@ if ( "${port}" == "" ) then
 endif
 
 # check user credentials
-set id = `$gtm_exe/geteuid`
+set id = `id -un`
 if ("${cmd}" == "client") then
 	if ( "${id}" == "root") then
 		echo "You need to be user to execute ${cmd}"

--- a/r120/outref/ydbdist.txt
+++ b/r120/outref/ydbdist.txt
@@ -19,8 +19,6 @@ Usage:
 
 Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
 
-#  Invoking executable : geteuid
-other
 #  Invoking executable : gtcm_gnp_server
 #  Invoking executable : gtcm_pkdisp
 #  Invoking executable : gtcm_server
@@ -64,8 +62,6 @@ Usage:
 
 Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
 
-#  Invoking executable : geteuid
-other
 #  Invoking executable : gtcm_gnp_server
 #  Invoking executable : gtcm_pkdisp
 #  Invoking executable : gtcm_server
@@ -109,8 +105,6 @@ information returned for each semaphore in set:
 #  Invoking executable : ftok
 %YDB-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
 %YDB-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
-#  Invoking executable : geteuid
-other
 #  Invoking executable : gtcm_gnp_server
 %YDB-E-DLLNOOPEN, Failed to load external dynamic library ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##
 %YDB-E-TEXT, ##TEST_PATH##/libyottadb##TEST_SHL_SUFFIX##: cannot open shared object file: No such file or directory
@@ -153,8 +147,6 @@ Usage:
 
 Reports IPC Key(s) (using id 1, or <number>) of <file1> <file2> ... <filen>
 
-#  Invoking executable : geteuid
-other
 #  Invoking executable : gtcm_gnp_server
 #  Invoking executable : gtcm_pkdisp
 #  Invoking executable : gtcm_server

--- a/r120/u_inref/ydbdist.csh
+++ b/r120/u_inref/ydbdist.csh
@@ -21,7 +21,7 @@ source $gtm_tst/com/portno_acquire.csh >>& portno.out
 # "gtcm_play" is not included in the below list because it produces some timing issues in the test runs
 # Not sure what that is and since this is a helper executable for a mostly unused functionality (GTCM OMI),
 # it is not considered as essential to test that out here.
-set executables = "mumps mupip dbcertify dse ftok geteuid gtcm_gnp_server gtcm_pkdisp gtcm_server gtcm_shmclean gtmsecshr lke semstat2"
+set executables = "mumps mupip dbcertify dse ftok gtcm_gnp_server gtcm_pkdisp gtcm_server gtcm_shmclean gtmsecshr lke semstat2"
 
 $echoline
 echo "# Test of <ydb_dist/gtm_dist> env vars and how they affect how executables in $saveydbdist are invoked"

--- a/v62000/inref/gtm7926callins.m
+++ b/v62000/inref/gtm7926callins.m
@@ -1,6 +1,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;								;
-;	Copyright 2014 Fidelity Information Services, Inc	;
+; Copyright 2014 Fidelity Information Services, Inc		;
+;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
 ;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
@@ -40,7 +43,7 @@ secshr
 iopi
 	set $ETRAP="zwrite $zstatus halt"
 	set pipe="pipe"
-	open pipe:(shell="/bin/sh":command="geteuid":parse)::"PIPE"
+	open pipe:(shell="/usr/local/bin/tcsh":command="id -un | sed 's/'$user'/other/g'":parse)::"PIPE"
 	use pipe
 	read euid
 	close pipe


### PR DESCRIPTION
The following types of changes were done.

1) Where geteuid was used because it is an executable in $ydb_dist, it was simply removed.

2) Where geteuid was used to output "other" (to indicate we are not "root" userid), it was
   replaced by "id -un | sed 's/'$user'/other/g'" that way the flow of the test and the
   reference file is not otherwise affected. Note that this change is not equivalent since
   geteuid prints "root" in case effective userid is root and "other" otherwise whereas
   the "id -un | sed" solution above will print "other" always. But this solution is better
   since this way even if the test is run as "root" userid, it will now pass whereas it
   would have previously failed (because the reference file has "other" whereas geteuid
   would have printed "root" in that case).

3) Where geteuid was used to get the current effective userid and check if it is "root" or
   not, "id -un" was used.